### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: rust
+sudo: false
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - RUSTFMT_VERSION=0.3.4
+cache: cargo
+
+matrix:
+  include:
+    - rust: stable
+      script:
+        - cargo test --all -- --nocapture
+        - cargo test --all --benches benches -- --nocapture
+    # rustfmt and clippy (behind the 'dev' feature) only work on the nightly toolchain.
+    # This build is considerably more thorough.
+    - rust: nightly
+      before_script: |
+        export PATH="$PATH:$HOME/.cargo/bin"
+        if [[ -n "`which cargo-fmt`" ]] && [[ "`cargo fmt --version`" != *"$RUSTFMT_VERSION"* ]]; then
+          cargo install rustfmt-nightly --version "$RUSTFMT_VERSION" --force
+        fi
+      script:
+        - cargo fmt -- --write-mode=diff
+        - cargo test --all --all-features -- --nocapture
+        - cargo test --all --all-features --benches benches -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   global:
     - RUST_BACKTRACE=1
-    - RUSTFMT_VERSION=0.3.4
+    - RUSTFMT_VERSION=0.3.6
 cache: cargo
 
 # `allow_failures` requires this, but we set it below.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ env:
     - RUSTFMT_VERSION=0.3.4
 cache: cargo
 
+# `allow_failures` requires this, but we set it below.
+rust:
+
 matrix:
+  allow_failures:
+    - rust: nightly
   include:
     - rust: stable
       script:


### PR DESCRIPTION
Adds a `.travis.yml` file to permit CI builds on Travis CI.

Contributes to #1.