### PR TITLE
Use stable Rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
-#![feature(conservative_impl_trait)]
 
 extern crate flat_map;
 extern crate fnv;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -27,6 +27,8 @@
 
 use std::cmp;
 use flat_map::FlatMap;
+use flat_map::flat_map;
+use std::iter::Chain;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ProgressState {
@@ -85,15 +87,11 @@ impl ProgressSet {
         progress
     }
 
-    // We need explicit lifetime here because of a compiler bug.
-    // See https://github.com/rust-lang/rust/issues/43396.
-    #[allow(needless_lifetimes)]
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a u64, &'a Progress)> {
+    pub fn iter(&self) -> Chain<flat_map::Iter<u64, Progress>, flat_map::Iter<u64, Progress>> {
         self.voters.iter().chain(&self.learners)
     }
 
-    #[allow(needless_lifetimes)]
-    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (&'a u64, &'a mut Progress)> {
+    pub fn iter_mut(&mut self) -> Chain<flat_map::IterMut<u64, Progress>, flat_map::IterMut<u64, Progress>> {
         self.voters.iter_mut().chain(&mut self.learners)
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,11 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
-#![feature(conservative_impl_trait)]
 
 extern crate kvproto;
 #[macro_use]


### PR DESCRIPTION
Migrates us to stable Rust by removing the `conservative_impl_trait`
feature.

Please note you still need to use `nightly` for `cargo test --features "dev"` since we use `clippy`.

Fixes #8. Contributes to #1.