### PR TITLE
Create a nix expression for `nix-shell`.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+let
+  pkgs = import <nixpkgs> { overlays = [ moz ]; };
+  moz = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+in {
+  devEnv = pkgs.stdenv.mkDerivation {
+    name = "raft-rs";
+    buildInputs = with pkgs; [
+      zlib
+      cmake
+      gcc
+      gnumake
+      openssl
+      go
+      perl
+      (rustChannelOf { channel = "nightly"; }).rust
+    ];
+  };
+}


### PR DESCRIPTION
This scaffolds a basic nix expression that allows users of the `nix`
package manager to simply run `nix-shell` and get a fully working
development environment that builds `master`.

Test it by setting up the `nix` package manager then running:

```bash
nix-shell --pure
```

Then inside run:

```bash
cargo test --features "dev"
```