### PR TITLE
*: cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,21 @@ sudo: false
 env:
   global:
     - RUST_BACKTRACE=1
-    - RUSTFMT_VERSION=0.3.6
 cache: cargo
 
 # `allow_failures` requires this, but we set it below.
 rust:
-  - stable
-  - nightly
 
 matrix:
   allow_failures:
     # clippy (behind the 'dev' feature) only works on the nightly toolchain.
     # This build is considerably more thorough.
     - rust: nightly
+  include:
+  - rust: stable
+  - rust: nightly
+    env: FEATURES="--all-features"
+
 script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - cargo test --all --all-features -- --nocapture
-  - cargo test --all --all-features --benches benches -- --nocapture
+  - cargo test --all $FEATURES -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,15 @@ cache: cargo
 
 # `allow_failures` requires this, but we set it below.
 rust:
+  - stable
+  - nightly
 
 matrix:
   allow_failures:
-    - rust: nightly
-  include:
-    - rust: stable
-      script:
-        - cargo test --all -- --nocapture
-        - cargo test --all --benches benches -- --nocapture
-    # rustfmt and clippy (behind the 'dev' feature) only work on the nightly toolchain.
+    # clippy (behind the 'dev' feature) only works on the nightly toolchain.
     # This build is considerably more thorough.
     - rust: nightly
-      before_script: |
-        export PATH="$PATH:$HOME/.cargo/bin"
-        if [[ -n "`which cargo-fmt`" ]] && [[ "`cargo fmt --version`" != *"$RUSTFMT_VERSION"* ]]; then
-          cargo install rustfmt-nightly --version "$RUSTFMT_VERSION" --force
-        fi
-      script:
-        - cargo fmt -- --write-mode=diff
-        - cargo test --all --all-features -- --nocapture
-        - cargo test --all --all-features --benches benches -- --nocapture
+script:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+  - cargo test --all --all-features -- --nocapture
+  - cargo test --all --all-features --benches benches -- --nocapture

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Using `rustup` you can get started this way:
 ```bash
 rustup override set stable
 rustup toolchain install nightly
-cargo +nightly install rustfmt-nightly
 ```
 
 In order to have your PR merged running the following must finish without error:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::{cmp, io, result};
 use std::error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
@@ -35,9 +34,9 @@ extern crate fnv;
 extern crate kvproto;
 #[macro_use]
 extern crate log;
+extern crate protobuf;
 #[macro_use]
 extern crate quick_error;
-extern crate protobuf;
 extern crate rand;
 
 mod raft_log;

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -25,7 +25,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use kvproto::eraftpb::{Entry, Snapshot};
 
 // unstable.entries[i] has raft log position i+unstable.offset.
@@ -42,7 +41,6 @@ pub struct Unstable {
 
     pub tag: String,
 }
-
 
 impl Unstable {
     pub fn new(offset: u64, tag: String) -> Unstable {
@@ -159,16 +157,11 @@ impl Unstable {
         if lo < self.offset || hi > upper {
             panic!(
                 "{} unstable.slice[{}, {}] out of bound[{}, {}]",
-                self.tag,
-                lo,
-                hi,
-                self.offset,
-                upper
+                self.tag, lo, hi, self.offset, upper
             )
         }
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -307,7 +300,6 @@ mod test {
         }
     }
 
-
     #[test]
     fn test_restore() {
         let mut u = Unstable {
@@ -417,7 +409,6 @@ mod test {
                 5,
                 vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)],
             ),
-
             // replace to unstable entries
             (
                 vec![new_entry(5, 1)],
@@ -427,7 +418,6 @@ mod test {
                 5,
                 vec![new_entry(5, 2), new_entry(6, 2)],
             ),
-
             (
                 vec![new_entry(5, 1)],
                 5,
@@ -436,7 +426,6 @@ mod test {
                 4,
                 vec![new_entry(4, 2), new_entry(5, 2), new_entry(6, 2)],
             ),
-
             // truncate existing entries and append
             (
                 vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)],
@@ -446,7 +435,6 @@ mod test {
                 5,
                 vec![new_entry(5, 1), new_entry(6, 2)],
             ),
-
             (
                 vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)],
                 5,
@@ -461,7 +449,6 @@ mod test {
                 ],
             ),
         ];
-
 
         for (entries, offset, snapshot, to_append, woffset, wentries) in tests {
             let mut u = Unstable {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -91,7 +91,9 @@ impl ProgressSet {
         self.voters.iter().chain(&self.learners)
     }
 
-    pub fn iter_mut(&mut self) -> Chain<flat_map::IterMut<u64, Progress>, flat_map::IterMut<u64, Progress>> {
+    pub fn iter_mut(
+        &mut self,
+    ) -> Chain<flat_map::IterMut<u64, Progress>, flat_map::IterMut<u64, Progress>> {
         self.voters.iter_mut().chain(&mut self.learners)
     }
 
@@ -338,7 +340,6 @@ impl Inflights {
                 // found the first large inflight
                 break;
             }
-
 
             // increase index and maybe rotate
             idx += 1;

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -93,8 +93,7 @@ impl<T: Storage> RaftLog<T> {
             Ok(t) => t,
             Err(e) => panic!(
                 "{} unexpected error when getting the last term: {:?}",
-                self.tag,
-                e
+                self.tag, e
             ),
         }
     }
@@ -120,8 +119,8 @@ impl<T: Storage> RaftLog<T> {
             Some(term) => Ok(term),
             _ => self.store.term(idx).map_err(|e| {
                 match e {
-                    Error::Store(StorageError::Compacted) |
-                    Error::Store(StorageError::Unavailable) => {}
+                    Error::Store(StorageError::Compacted)
+                    | Error::Store(StorageError::Unavailable) => {}
                     _ => panic!("{} unexpected error: {:?}", self.tag, e),
                 }
                 e
@@ -142,7 +141,6 @@ impl<T: Storage> RaftLog<T> {
             None => self.store.last_index().unwrap(),
         }
     }
-
 
     // find_conflict finds the index of the conflict.
     // It returns the first index of conflicting entries between the existing
@@ -193,9 +191,7 @@ impl<T: Storage> RaftLog<T> {
             } else if conflict_idx <= self.committed {
                 panic!(
                     "{} entry {} conflict with committed entry {}",
-                    self.tag,
-                    conflict_idx,
-                    self.committed
+                    self.tag, conflict_idx, self.committed
                 )
             } else {
                 let offset = idx + 1;
@@ -230,10 +226,7 @@ impl<T: Storage> RaftLog<T> {
         if self.committed < idx || idx < self.applied {
             panic!(
                 "{} applied({}) is out of range [prev_applied({}), committed({})",
-                self.tag,
-                idx,
-                self.applied,
-                self.committed
+                self.tag, idx, self.applied, self.committed
             )
         }
         self.applied = idx;
@@ -264,9 +257,7 @@ impl<T: Storage> RaftLog<T> {
         if after < self.committed {
             panic!(
                 "{} after {} is out of range [committed {}]",
-                self.tag,
-                after,
-                self.committed
+                self.tag, after, self.committed
             )
         }
         self.unstable.truncate_and_append(ents);
@@ -385,15 +376,15 @@ impl<T: Storage> RaftLog<T> {
             return Err(err.unwrap());
         }
 
-
         let mut ents = vec![];
         if low == high {
             return Ok(ents);
         }
 
         if low < self.unstable.offset {
-            let stored_entries = self.store
-                .entries(low, cmp::min(high, self.unstable.offset), max_size);
+            let stored_entries =
+                self.store
+                    .entries(low, cmp::min(high, self.unstable.offset), max_size);
             if stored_entries.is_err() {
                 let e = stored_entries.unwrap_err();
                 match e {
@@ -434,7 +425,6 @@ impl<T: Storage> RaftLog<T> {
         self.unstable.restore(snapshot);
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -731,11 +721,9 @@ mod test {
             (snap_index + 1, snap_term, vec![], snap_index + 1),
             (snap_index, snap_term, vec![], snap_index + 1),
             (snap_index - 1, snap_term, vec![], snap_index + 1),
-
             (snap_index + 1, snap_term + 1, vec![], snap_index + 1),
             (snap_index, snap_term + 1, vec![], snap_index + 1),
             (snap_index - 1, snap_term + 1, vec![], snap_index + 1),
-
             (
                 snap_index + 1,
                 snap_term,
@@ -754,7 +742,6 @@ mod test {
                 vec![new_entry(snap_index + 1, snap_term)],
                 snap_index + 1,
             ),
-
             (
                 snap_index + 1,
                 snap_term + 1,
@@ -787,9 +774,7 @@ mod test {
             if raft_log.unstable.offset != wunstable {
                 panic!(
                     "#{}: unstable = {}, want {}",
-                    i,
-                    raft_log.unstable.offset,
-                    wunstable
+                    i, raft_log.unstable.offset, wunstable
                 );
             }
         }
@@ -806,9 +791,7 @@ mod test {
             if raft_log.unstable.offset != wunstable {
                 panic!(
                     "#{}: unstable = {}, want {}",
-                    i,
-                    raft_log.unstable.offset,
-                    wunstable
+                    i, raft_log.unstable.offset, wunstable
                 );
             }
         }
@@ -870,9 +853,7 @@ mod test {
             if next_entries != expect_entries.map(|n| n.to_vec()) {
                 panic!(
                     "#{}: next_entries = {:?}, want {:?}",
-                    i,
-                    next_entries,
-                    expect_entries
+                    i, next_entries, expect_entries
                 );
             }
         }
@@ -947,7 +928,6 @@ mod test {
                 false,
             ),
             (last, last + 1, raft_log::NO_LIMIT, vec![], true),
-
             // test limit
             (
                 half - 1,
@@ -1183,9 +1163,9 @@ mod test {
             let mut raft_log = new_raft_log(store);
             raft_log.append(&previous_ents);
             raft_log.committed = commit;
-            let res = panic::catch_unwind(AssertUnwindSafe(
-                || raft_log.maybe_append(index, log_term, committed, ents),
-            ));
+            let res = panic::catch_unwind(AssertUnwindSafe(|| {
+                raft_log.maybe_append(index, log_term, committed, ents)
+            }));
             if res.is_err() ^ wpanic {
                 panic!("#{}: panic = {}, want {}", i, res.is_err(), wpanic);
             }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -25,7 +25,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::mem;
 
 use protobuf::{self, RepeatedField};
@@ -52,22 +51,22 @@ pub enum SnapshotStatus {
 
 fn is_local_msg(t: MessageType) -> bool {
     match t {
-        MessageType::MsgHup |
-        MessageType::MsgBeat |
-        MessageType::MsgUnreachable |
-        MessageType::MsgSnapStatus |
-        MessageType::MsgCheckQuorum => true,
+        MessageType::MsgHup
+        | MessageType::MsgBeat
+        | MessageType::MsgUnreachable
+        | MessageType::MsgSnapStatus
+        | MessageType::MsgCheckQuorum => true,
         _ => false,
     }
 }
 
 fn is_response_msg(t: MessageType) -> bool {
     match t {
-        MessageType::MsgAppendResponse |
-        MessageType::MsgRequestVoteResponse |
-        MessageType::MsgHeartbeatResponse |
-        MessageType::MsgUnreachable |
-        MessageType::MsgRequestPreVoteResponse => true,
+        MessageType::MsgAppendResponse
+        | MessageType::MsgRequestVoteResponse
+        | MessageType::MsgHeartbeatResponse
+        | MessageType::MsgUnreachable
+        | MessageType::MsgRequestPreVoteResponse => true,
         _ => false,
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -25,7 +25,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use kvproto::eraftpb::{ConfState, Entry, HardState, Snapshot};
@@ -193,7 +192,6 @@ impl MemStorageCore {
         } else {
             ents
         };
-
 
         let offset = te[0].get_index() - self.entries[0].get_index();
         if self.entries.len() as u64 > offset {

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,12 +25,14 @@ pub fn limit_size<T: Message + Clone>(entries: &mut Vec<T>, max: u64) {
     let mut size = 0;
     let limit = entries
         .iter()
-        .take_while(|&e| if size == 0 {
-            size += Message::compute_size(e) as u64;
-            true
-        } else {
-            size += Message::compute_size(e) as u64;
-            size <= max
+        .take_while(|&e| {
+            if size == 0 {
+                size += Message::compute_size(e) as u64;
+                true
+            } else {
+                size += Message::compute_size(e) as u64;
+                size <= max
+            }
         })
         .count();
 

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 mod test_raft;
 mod test_raft_snap;
 mod test_raft_paper;

--- a/tests/cases/test_raft.rs
+++ b/tests/cases/test_raft.rs
@@ -111,7 +111,6 @@ pub fn new_test_raft_with_config(config: &Config, storage: MemStorage) -> Interf
     Interface::new(Raft::new(config, storage))
 }
 
-
 fn read_messages<T: Storage>(raft: &mut Raft<T>) -> Vec<Message> {
     raft.msgs.drain(..).collect()
 }
@@ -142,7 +141,6 @@ fn voted_with_config(vote: u64, term: u64, pre_vote: bool) -> Interface {
     raft.reset(term);
     raft
 }
-
 
 fn next_ents(r: &mut Raft<MemStorage>, s: &MemStorage) -> Vec<Entry> {
     s.wl()
@@ -658,7 +656,6 @@ fn test_leader_election_with_config(pre_vote: bool) {
             StateRole::Leader,
             1,
         ),
-
         // three logs further along than 0, but in the same term so rejection
         // are returned instead of the votes being ignored.
         (
@@ -726,24 +723,18 @@ fn test_leader_cycle_with_config(pre_vote: bool) {
             if sm.id == campaigner_id && sm.state != StateRole::Leader {
                 panic!(
                     "pre_vote={}: campaigning node {} state = {:?}, want Leader",
-                    pre_vote,
-                    sm.id,
-                    sm.state
+                    pre_vote, sm.id, sm.state
                 );
             } else if sm.id != campaigner_id && sm.state != StateRole::Follower {
                 panic!(
                     "pre_vote={}: after campaign of node {}, node {} had state = {:?}, want \
                      Follower",
-                    pre_vote,
-                    campaigner_id,
-                    sm.id,
-                    sm.state
+                    pre_vote, campaigner_id, sm.id, sm.state
                 );
             }
         }
     }
 }
-
 
 #[test]
 fn test_leader_election_overwrite_newer_logs() {
@@ -824,7 +815,6 @@ fn test_leader_election_overwrite_newer_logs_with_config(pre_vote: bool) {
         );
     }
 }
-
 
 #[test]
 fn test_vote_from_any_state() {
@@ -958,7 +948,6 @@ fn test_log_replicatioin() {
             vec![new_message(1, 1, MessageType::MsgPropose, 1)],
             2,
         ),
-
         (
             Network::new(vec![None, None, None]),
             vec![
@@ -980,10 +969,7 @@ fn test_log_replicatioin() {
             if x.raft_log.committed != wcommitted {
                 panic!(
                     "#{}.{}: committed = {}, want {}",
-                    i,
-                    j,
-                    x.raft_log.committed,
-                    wcommitted
+                    i, j, x.raft_log.committed, wcommitted
                 );
             }
 
@@ -1124,9 +1110,7 @@ fn test_dueling_candidates() {
         if nt.peers[&id].state != state {
             panic!(
                 "#{}: state = {:?}, want {:?}",
-                i,
-                nt.peers[&id].state,
-                state
+                i, nt.peers[&id].state, state
             );
         }
         if nt.peers[&id].term != term {
@@ -1175,9 +1159,7 @@ fn test_dueling_pre_candidates() {
         if nt.peers[&id].state != state {
             panic!(
                 "#{}: state = {:?}, want {:?}",
-                i,
-                nt.peers[&id].state,
-                state
+                i, nt.peers[&id].state, state
             );
         }
         if nt.peers[&id].term != term {
@@ -1358,7 +1340,6 @@ fn test_commit() {
         (vec![1], vec![empty_entry(1, 1)], 2, 0),
         (vec![2], vec![empty_entry(1, 1), empty_entry(2, 2)], 2, 2),
         (vec![1], vec![empty_entry(2, 1)], 2, 1),
-
         // odd
         (
             vec![2, 1, 1],
@@ -1384,7 +1365,6 @@ fn test_commit() {
             2,
             0,
         ),
-
         // even
         (
             vec![2, 1, 1, 1],
@@ -1481,9 +1461,8 @@ fn test_pass_election_timeout() {
 #[test]
 fn test_step_ignore_old_term_msg() {
     let mut sm = new_test_raft(1, vec![1], 10, 1, new_storage());
-    let panic_before_step_state = Box::new(|_: &Message| {
-        panic!("before step state function hook called unexpectedly")
-    });
+    let panic_before_step_state =
+        Box::new(|_: &Message| panic!("before step state function hook called unexpectedly"));
     sm.before_step_state = Some(panic_before_step_state);
     sm.term = 2;
     let mut m = new_message(0, 0, MessageType::MsgAppend, 0);
@@ -1517,14 +1496,12 @@ fn test_handle_msg_append() {
         // Ensure 1
         (nm(2, 3, 2, 3, None), 2, 0, true), // previous log mismatch
         (nm(2, 3, 3, 3, None), 2, 0, true), // previous log non-exist
-
         // Ensure 2
         (nm(2, 1, 1, 1, None), 2, 1, false),
         (nm(2, 0, 0, 1, Some(vec![(1, 2)])), 1, 1, false),
         (nm(2, 2, 2, 3, Some(vec![(3, 2), (4, 2)])), 4, 3, false),
         (nm(2, 2, 2, 4, Some(vec![(3, 2)])), 3, 3, false),
         (nm(2, 1, 1, 4, Some(vec![(2, 2)])), 2, 2, false),
-
         // Ensure 3
         (nm(1, 1, 1, 3, None), 2, 1, false), // match entry 1, commit up to last new entry 1
         (nm(1, 1, 1, 3, Some(vec![(2, 2)])), 2, 2, false), // match entry 1, commit up to last new
@@ -1554,9 +1531,7 @@ fn test_handle_msg_append() {
         if sm.raft_log.committed != w_commit {
             panic!(
                 "#{}: committed = {}, want {}",
-                j,
-                sm.raft_log.committed,
-                w_commit
+                j, sm.raft_log.committed, w_commit
             );
         }
         let m = sm.read_messages();
@@ -1596,9 +1571,7 @@ fn test_handle_heartbeat() {
         if sm.raft_log.committed != w_commit {
             panic!(
                 "#{}: committed = {}, want = {}",
-                i,
-                sm.raft_log.committed,
-                w_commit
+                i, sm.raft_log.committed, w_commit
             );
         }
         let m = sm.read_messages();
@@ -1756,25 +1729,20 @@ fn test_recv_msg_request_vote_for_type(msg_type: MessageType) {
         (StateRole::Follower, 0, 1, INVALID_ID, true),
         (StateRole::Follower, 0, 2, INVALID_ID, true),
         (StateRole::Follower, 0, 3, INVALID_ID, false),
-
         (StateRole::Follower, 1, 0, INVALID_ID, true),
         (StateRole::Follower, 1, 1, INVALID_ID, true),
         (StateRole::Follower, 1, 2, INVALID_ID, true),
         (StateRole::Follower, 1, 3, INVALID_ID, false),
-
         (StateRole::Follower, 2, 0, INVALID_ID, true),
         (StateRole::Follower, 2, 1, INVALID_ID, true),
         (StateRole::Follower, 2, 2, INVALID_ID, false),
         (StateRole::Follower, 2, 3, INVALID_ID, false),
-
         (StateRole::Follower, 3, 0, INVALID_ID, true),
         (StateRole::Follower, 3, 1, INVALID_ID, true),
         (StateRole::Follower, 3, 2, INVALID_ID, false),
         (StateRole::Follower, 3, 3, INVALID_ID, false),
-
         (StateRole::Follower, 3, 2, 2, false),
         (StateRole::Follower, 3, 2, 1, true),
-
         (StateRole::Leader, 3, 3, 1, true),
         (StateRole::PreCandidate, 3, 3, 1, true),
         (StateRole::Candidate, 3, 3, 1, true),
@@ -1843,7 +1811,6 @@ fn test_state_transition() {
             INVALID_ID,
         ),
         (StateRole::Follower, StateRole::Leader, false, 0, INVALID_ID),
-
         (
             StateRole::PreCandidate,
             StateRole::Follower,
@@ -1866,7 +1833,6 @@ fn test_state_transition() {
             INVALID_ID,
         ),
         (StateRole::PreCandidate, StateRole::Leader, true, 0, 1),
-
         (
             StateRole::Candidate,
             StateRole::Follower,
@@ -1889,7 +1855,6 @@ fn test_state_transition() {
             INVALID_ID,
         ),
         (StateRole::Candidate, StateRole::Leader, true, 0, 1),
-
         (StateRole::Leader, StateRole::Follower, true, 1, INVALID_ID),
         (
             StateRole::Leader,
@@ -2276,9 +2241,7 @@ fn test_read_only_option_safe() {
         if rs.request_ctx != vec_wctx {
             panic!(
                 "#{}: request_ctx = {:?}, want {:?}",
-                i,
-                rs.request_ctx,
-                vec_wctx
+                i, rs.request_ctx, vec_wctx
             )
         }
     }
@@ -2350,9 +2313,7 @@ fn test_read_only_option_lease() {
         if rs.request_ctx != vec_wctx {
             panic!(
                 "#{}: request_ctx = {:?}, want {:?}",
-                i,
-                rs.request_ctx,
-                vec_wctx
+                i, rs.request_ctx, vec_wctx
             );
         }
     }
@@ -2968,10 +2929,7 @@ fn test_step_ignore_config() {
 // based on uncommitted entries.
 #[test]
 fn test_new_leader_pending_config() {
-    let mut tests = vec![
-        (false, 0),
-        (true, 1),
-    ];
+    let mut tests = vec![(false, 0), (true, 1)];
     for (i, (add_entry, wpending_index)) in tests.drain(..).enumerate() {
         let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
         let mut e = Entry::new();
@@ -2981,12 +2939,10 @@ fn test_new_leader_pending_config() {
         }
         r.become_candidate();
         r.become_leader();
-        if r.pending_conf_index != wpending_index{
+        if r.pending_conf_index != wpending_index {
             panic!(
                 "#{}: pending_conf_index = {}, want {}",
-                i,
-                r.pending_conf_index,
-                wpending_index
+                i, r.pending_conf_index, wpending_index
             );
         }
     }
@@ -3082,7 +3038,6 @@ fn test_campaign_while_leader() {
 fn test_pre_campaign_while_leader() {
     test_campaign_while_leader_with_pre_vote(true);
 }
-
 
 fn test_campaign_while_leader_with_pre_vote(pre_vote: bool) {
     let mut r = new_test_raft_with_prevote(1, vec![1], 5, 1, new_storage(), pre_vote);
@@ -3436,10 +3391,7 @@ fn check_leader_transfer_state(r: &Raft<MemStorage>, state: StateRole, lead: u64
     if r.state != state || r.leader_id != lead {
         panic!(
             "after transferring, node has state {:?} lead {}, want state {:?} lead {}",
-            r.state,
-            r.leader_id,
-            state,
-            lead
+            r.state, r.leader_id, state, lead
         );
     }
     assert_eq!(r.lead_transferee, None);
@@ -3678,7 +3630,6 @@ fn test_learner_receive_snapshot() {
     n1.restore(s);
     let committed = n1.raft_log.committed;
     n1.raft_log.applied_to(committed);
-
 
     let mut network = Network::new(vec![Some(n1), Some(n2)]);
 

--- a/tests/cases/test_raft_paper.rs
+++ b/tests/cases/test_raft_paper.rs
@@ -116,9 +116,8 @@ fn test_update_term_from_message(state: StateRole) {
 #[test]
 fn test_reject_stale_term_message() {
     let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
-    let panic_before_step_state = Box::new(|_: &Message| {
-        panic!("before step state function hook called unexpectedly")
-    });
+    let panic_before_step_state =
+        Box::new(|_: &Message| panic!("before step state function hook called unexpectedly"));
     r.before_step_state = Some(panic_before_step_state);
     r.load_state(hard_state(2, 0, 0));
 
@@ -238,7 +237,6 @@ fn test_leader_election_in_one_round_rpc() {
         ),
         (5, map!(2 => true, 3 => true, 4 => true), StateRole::Leader),
         (5, map!(2 => true, 3 => true), StateRole::Leader),
-
         // return to follower state if it receives vote denial from a majority
         (3, map!(2 => false, 3 => false), StateRole::Follower),
         (
@@ -251,7 +249,6 @@ fn test_leader_election_in_one_round_rpc() {
             map!(2 => true, 3 => false, 4 => false, 5 => false),
             StateRole::Follower,
         ),
-
         // stay in candidate if it does not obtain the majority
         (3, map!(), StateRole::Candidate),
         (5, map!(2 => true), StateRole::Candidate),
@@ -635,9 +632,7 @@ fn test_follower_commit_entry() {
         if r.raft_log.committed != commit {
             panic!(
                 "#{}: committed = {}, want {}",
-                i,
-                r.raft_log.committed,
-                commit
+                i, r.raft_log.committed, commit
             );
         }
         let wents = Some(ents[..commit as usize].to_vec());
@@ -662,7 +657,6 @@ fn test_follower_check_msg_append() {
         (ents[0].get_term(), ents[0].get_index(), 1, false, 0),
         // match with uncommitted entries
         (ents[1].get_term(), ents[1].get_index(), 2, false, 0),
-
         // unmatch with existing entry
         (
             ents[0].get_term(),
@@ -723,7 +717,6 @@ fn test_follower_append_entries() {
             vec![empty_entry(1, 1), empty_entry(2, 2), empty_entry(3, 3)],
             vec![empty_entry(3, 3)],
         ),
-
         (
             1,
             1,
@@ -731,7 +724,6 @@ fn test_follower_append_entries() {
             vec![empty_entry(1, 1), empty_entry(3, 2), empty_entry(4, 3)],
             vec![empty_entry(3, 2), empty_entry(4, 3)],
         ),
-
         (
             0,
             0,
@@ -900,9 +892,7 @@ fn test_leader_sync_follower_log() {
         if lead_str != follower_str {
             panic!(
                 "#{}: lead str: {}, follower_str: {}",
-                i,
-                lead_str,
-                follower_str
+                i, lead_str, follower_str
             );
         }
     }
@@ -1056,9 +1046,7 @@ fn test_leader_only_commits_log_from_current_term() {
         if r.raft_log.committed != wcommit {
             panic!(
                 "#{}: commit = {}, want {}",
-                i,
-                r.raft_log.committed,
-                wcommit
+                i, r.raft_log.committed, wcommit
             );
         }
     }

--- a/tests/cases/test_raft_snap.rs
+++ b/tests/cases/test_raft_snap.rs
@@ -32,7 +32,6 @@ fn testing_snap() -> Snapshot {
     new_snapshot(11, 11, vec![1, 2])
 }
 
-
 #[test]
 fn test_sending_snapshot_set_pending_snapshot() {
     let mut sm = new_test_raft(1, vec![1], 10, 1, new_storage());

--- a/tests/cases/test_raw_node.rs
+++ b/tests/cases/test_raw_node.rs
@@ -110,7 +110,6 @@ fn test_raw_node_step() {
     }
 }
 
-
 // test_raw_node_read_index_to_old_leader ensures that MsgReadIndex to old leader gets
 // forward to the new leader and 'send' method does not attach its term
 #[test]
@@ -325,7 +324,6 @@ fn test_raw_node_read_index() {
     assert_eq!(wrequest_ctx, msgs[0].get_entries()[0].get_data());
 }
 
-
 // test_raw_node_start ensures that a node can be started correctly. The node should
 // start with correct configuration change entries, and can accept and commit
 // proposals.
@@ -428,7 +426,7 @@ fn test_skip_bcast_commit() {
 
     // elect r1 as leader
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
-    
+
     // Without bcast commit, followers will not update its commit index immediately.
     let mut test_entries = Entry::new();
     test_entries.set_data(b"testdata".to_vec());


### PR DESCRIPTION
This pr formats code with rustfmt-nightly 0.3.4.

I propose to use the same rustfmt as TiKV during development. However rustfmt does not always work with the nightly rustc, so let's just skip format check in the CI build for simplicity. We can always format all the code when necessary.