### PR TITLE
*: bump 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "raft"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
-keywords = ["raft"]
+keywords = ["raft", "distributed-systems", "ha"]
 repository = "https://github.com/pingcap/raft-rs"
 readme = "README.md"
 homepage = "https://github.com/pingcap/raft-rs"
@@ -24,3 +24,5 @@ clippy = {version = "*", optional = true}
 default = []
 dev = ["clippy"]
 
+[badges]
+travis-ci = { repository = "pingcap/raft-rs" }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cargo watch -s "cargo check --features dev"
 
 ## Acknowledgments
 
-Thanks [etcd](https://github.com/coreos/etcd) for providing the amazing go implementations!
+Thanks [etcd](https://github.com/coreos/etcd) for providing the amazing Go implementation!
 
 ## Projects using raft
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ Two well known Distributed Consensus Algorithms are Paxos and Raft. Paxos is use
 
 ## Using It
 
-Currently `raft-rs` is only available as a Git based dependency. We're working towards making a release available on [crates.io](https://crates.io/) in the future, check out [tracking issue](https://github.com/pingcap/raft-rs/issues/1).
+To include this project as a dependency:
+
+```
+[dependencies]
+raft = "0.1"
+```
+
+This crate is ready for production usage, but there are still [several jobs](https://github.com/pingcap/raft-rs/issues/35) need to be finished before reaching 1.0.
 
 ## Developing
 
@@ -44,3 +51,11 @@ You may optionally want to install `cargo-check` to allow for automated rebuildi
 ```bash
 cargo watch -s "cargo check --features dev"
 ```
+
+## Acknowledgments
+
+Thanks [etcd](https://github.com/coreos/etcd) for providing the amazing go implementations!
+
+## Projects using raft
+
+- [TiKV](https://github.com/pingcap/tikv), a distributed transactional key value database powered by Rust and Raft.


### PR DESCRIPTION
Close #1.

We release a version to not block further work of TiKV, but there still be places need to be enhanced before reaching 1.0, as tracked by #35.
