### PR TITLE
dependency: remove clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   global:
     - RUST_BACKTRACE=1
-    - CLIPPY_VERSION=0.0.177
+    - CLIPPY_VERSION=0.0.179
     - RUSTFLAGS="-D warnings"
 cache: cargo
 
@@ -13,11 +13,11 @@ rust:
 matrix:
   include:
   - rust: stable
-  - rust: nightly-2018-01-01
+  - rust: nightly-2018-01-12
     install:
+      - export PATH="$PATH:$HOME/.cargo/bin"
       - if [[ `cargo clippy -- --version` != $CLIPPY_VERSION* ]]; then cargo install -f clippy --version $CLIPPY_VERSION; fi
 
 script:
-  - export PATH="$PATH:$HOME/.cargo/bin"
   - if `which cargo-clippy &>/dev/null`; then cargo clippy; fi
   - cargo test --all -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   global:
     - RUST_BACKTRACE=1
     - CLIPPY_VERSION=0.0.177
+    - RUSTFLAGS="-D warnings"
 cache: cargo
 
 # `allow_failures` requires this, but we set it below.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ matrix:
 script:
   - export PATH="$PATH:$HOME/.cargo/bin"
   - which cargo-clippy && cargo clippy
-  - cargo test --all $FEATURES -- --nocapture
+  - cargo test --all -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,12 @@ cache: cargo
 rust:
 
 matrix:
-  allow_failures:
-    # clippy (behind the 'dev' feature) only works on the nightly toolchain.
-    # This build is considerably more thorough.
-    - rust: nightly
   include:
   - rust: stable
   - rust: nightly
-    env: FEATURES="--all-features"
+    install: rm -f ~/.cargo/bin/cargo-clippy && cargo install -f clippy || true
 
 script:
   - export PATH="$PATH:$HOME/.cargo/bin"
+  - which cargo-clippy && cargo clippy
   - cargo test --all $FEATURES -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 env:
   global:
     - RUST_BACKTRACE=1
+    - CLIPPY_VERSION=0.0.177
 cache: cargo
 
 # `allow_failures` requires this, but we set it below.
@@ -11,10 +12,11 @@ rust:
 matrix:
   include:
   - rust: stable
-  - rust: nightly
-    install: rm -f ~/.cargo/bin/cargo-clippy && cargo install -f clippy || true
+  - rust: nightly-2018-01-01
+    install:
+      - if [[ `cargo clippy -- --version` != $CLIPPY_VERSION* ]]; then cargo install -f clippy --version $CLIPPY_VERSION; fi
 
 script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - which cargo-clippy && cargo clippy
+  - if `which cargo-clippy &>/dev/null`; then cargo clippy; fi
   - cargo test --all -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/pingcap/raft-rs"
 documentation = "https://docs.rs/raft"
 description = "The rust language implementation of Raft algorithm."
-categories = ["Algorithms", "Database implementations"]
+categories = ["algorithms", "database-implementations"]
 
 [dependencies]
 flat_map = "0.0.4"
@@ -18,11 +18,6 @@ log = "0.3"
 protobuf = "1.2"
 quick-error = "0.2"
 rand = "0.4"
-clippy = {version = "*", optional = true}
-
-[features]
-default = []
-dev = ["clippy"]
 
 [badges]
 travis-ci = { repository = "pingcap/raft-rs" }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -40,12 +40,12 @@ use flat_map::FlatMap;
 
 // CAMPAIGN_PRE_ELECTION represents the first phase of a normal election when
 // Config.pre_vote is true.
-const CAMPAIGN_PRE_ELECTION: &'static [u8] = b"CampaignPreElection";
+const CAMPAIGN_PRE_ELECTION: &[u8] = b"CampaignPreElection";
 // CAMPAIGN_ELECTION represents a normal (time-based) election (the second phase
 // of the election when Config.pre_vote is true).
-const CAMPAIGN_ELECTION: &'static [u8] = b"CampaignElection";
+const CAMPAIGN_ELECTION: &[u8] = b"CampaignElection";
 // CAMPAIGN_TRANSFER represents the type of leader transfer.
-const CAMPAIGN_TRANSFER: &'static [u8] = b"CampaignTransfer";
+const CAMPAIGN_TRANSFER: &[u8] = b"CampaignTransfer";
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum StateRole {
@@ -338,7 +338,7 @@ impl<T: Storage> Raft<T> {
         }
 
         if rs.hard_state != HardState::new() {
-            r.load_state(rs.hard_state);
+            r.load_state(&rs.hard_state);
         }
         if c.applied > 0 {
             r.raft_log.applied_to(c.applied);
@@ -607,7 +607,8 @@ impl<T: Storage> Raft<T> {
         self.bcast_heartbeat_with_ctx(ctx)
     }
 
-    pub fn bcast_heartbeat_with_ctx(&mut self, ctx: Option<Vec<u8>>) {
+    #[allow(needless_pass_by_value)]
+    fn bcast_heartbeat_with_ctx(&mut self, ctx: Option<Vec<u8>>) {
         let self_id = self.id;
         let mut prs = self.take_prs();
         prs.iter_mut()
@@ -1511,7 +1512,7 @@ impl<T: Storage> Raft<T> {
             }
             MessageType::MsgAppend => {
                 self.become_follower(term, m.get_from());
-                self.handle_append_entries(m);
+                self.handle_append_entries(&m);
             }
             MessageType::MsgHeartbeat => {
                 self.become_follower(term, m.get_from());
@@ -1581,7 +1582,7 @@ impl<T: Storage> Raft<T> {
             MessageType::MsgAppend => {
                 self.election_elapsed = 0;
                 self.leader_id = m.get_from();
-                self.handle_append_entries(m);
+                self.handle_append_entries(&m);
             }
             MessageType::MsgHeartbeat => {
                 self.election_elapsed = 0;
@@ -1658,7 +1659,7 @@ impl<T: Storage> Raft<T> {
     }
 
     // TODO: revoke pub when there is a better way to test.
-    pub fn handle_append_entries(&mut self, m: Message) {
+    pub fn handle_append_entries(&mut self, m: &Message) {
         if m.get_index() < self.raft_log.committed {
             let mut to_send = Message::new();
             to_send.set_to(m.get_from());
@@ -1915,7 +1916,7 @@ impl<T: Storage> Raft<T> {
     }
 
     // TODO: revoke pub when there is a better way to test.
-    pub fn load_state(&mut self, hs: HardState) {
+    pub fn load_state(&mut self, hs: &HardState) {
         if hs.get_commit() < self.raft_log.committed || hs.get_commit() > self.raft_log.last_index()
         {
             panic!(

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -89,10 +89,13 @@ impl ReadOnly {
     /// the read only request.
     /// `m` is the original read only request message from the local or remote node.
     pub fn add_request(&mut self, index: u64, m: Message) {
-        let ctx = m.get_entries()[0].get_data().to_vec();
-        if self.pending_read_index.contains_key(&ctx) {
-            return;
-        }
+        let ctx = {
+            let key = m.get_entries()[0].get_data();
+            if self.pending_read_index.contains_key(key) {
+                return;
+            }
+            key.to_vec()
+        };
         let status = ReadIndexStatus {
             req: m,
             index: index,

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,10 +27,10 @@ pub fn limit_size<T: Message + Clone>(entries: &mut Vec<T>, max: u64) {
         .iter()
         .take_while(|&e| {
             if size == 0 {
-                size += Message::compute_size(e) as u64;
+                size += u64::from(Message::compute_size(e));
                 true
             } else {
-                size += Message::compute_size(e) as u64;
+                size += u64::from(Message::compute_size(e));
                 size <= max
             }
         })

--- a/tests/cases/test_raw_node.rs
+++ b/tests/cases/test_raw_node.rs
@@ -87,7 +87,7 @@ fn new_raw_node(
     RawNode::new(
         &new_test_config(id, peers, election, heartbeat),
         storage,
-        &peer_nodes,
+        peer_nodes,
     ).unwrap()
 }
 
@@ -312,7 +312,7 @@ fn test_raw_node_propose_add_learner_node() {
 #[test]
 fn test_raw_node_read_index() {
     let a = Rc::new(RefCell::new(Vec::new()));
-    let b = a.clone();
+    let b = Rc::clone(&a);
     let before_step_state = Box::new(move |m: &Message| {
         b.borrow_mut().push(m.clone());
         true


### PR DESCRIPTION
Because version '*' is rejected by crates.io, so clippy needs to be opt out from dependency. The pr uses the command mode of clippy.