### PR TITLE
*: use fxhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,11 @@ description = "The rust language implementation of Raft algorithm."
 categories = ["algorithms", "database-implementations"]
 
 [dependencies]
-flat_map = "0.0.4"
-fnv = "1.0"
 log = "0.3"
 protobuf = "1.2"
 quick-error = "0.2"
 rand = "0.4"
+fxhash = "0.2.1"
 
 [badges]
 travis-ci = { repository = "pingcap/raft-rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,7 @@
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 
-extern crate flat_map;
-extern crate fnv;
+extern crate fxhash;
 #[macro_use]
 extern crate log;
 extern crate protobuf;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -26,9 +26,9 @@
 // limitations under the License.
 
 use std::cmp;
-use flat_map::FlatMap;
-use flat_map::flat_map;
 use std::iter::Chain;
+use std::collections::hash_map::{HashMap, Iter, IterMut};
+use fxhash::FxHashMap;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ProgressState {
@@ -47,23 +47,23 @@ impl Default for ProgressState {
 /// which could be `Leader`, `Follower` and `Learner`.
 #[derive(Default, Clone)]
 pub struct ProgressSet {
-    voters: FlatMap<u64, Progress>,
-    learners: FlatMap<u64, Progress>,
+    voters: FxHashMap<u64, Progress>,
+    learners: FxHashMap<u64, Progress>,
 }
 
 impl ProgressSet {
     pub fn new(voter_size: usize, learner_size: usize) -> Self {
         ProgressSet {
-            voters: FlatMap::with_capacity(voter_size),
-            learners: FlatMap::with_capacity(learner_size),
+            voters: HashMap::with_capacity_and_hasher(voter_size, Default::default()),
+            learners: HashMap::with_capacity_and_hasher(learner_size, Default::default()),
         }
     }
 
-    pub fn voters(&self) -> &FlatMap<u64, Progress> {
+    pub fn voters(&self) -> &FxHashMap<u64, Progress> {
         &self.voters
     }
 
-    pub fn learners(&self) -> &FlatMap<u64, Progress> {
+    pub fn learners(&self) -> &FxHashMap<u64, Progress> {
         &self.learners
     }
 
@@ -93,13 +93,11 @@ impl ProgressSet {
         progress
     }
 
-    pub fn iter(&self) -> Chain<flat_map::Iter<u64, Progress>, flat_map::Iter<u64, Progress>> {
+    pub fn iter(&self) -> Chain<Iter<u64, Progress>, Iter<u64, Progress>> {
         self.voters.iter().chain(&self.learners)
     }
 
-    pub fn iter_mut(
-        &mut self,
-    ) -> Chain<flat_map::IterMut<u64, Progress>, flat_map::IterMut<u64, Progress>> {
+    pub fn iter_mut(&mut self) -> Chain<IterMut<u64, Progress>, IterMut<u64, Progress>> {
         self.voters.iter_mut().chain(&mut self.learners)
     }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -29,6 +29,7 @@ use std::cmp;
 
 use rand::{self, Rng};
 use eraftpb::{Entry, EntryType, HardState, Message, MessageType, Snapshot};
+use fxhash::FxHashMap;
 use protobuf::repeated::RepeatedField;
 
 use super::storage::Storage;
@@ -36,7 +37,6 @@ use super::progress::{Inflights, Progress, ProgressSet, ProgressState};
 use super::errors::{Error, Result, StorageError};
 use super::raft_log::{self, RaftLog};
 use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};
-use flat_map::FlatMap;
 
 // CAMPAIGN_PRE_ELECTION represents the first phase of a normal election when
 // Config.pre_vote is true.
@@ -192,7 +192,7 @@ pub struct Raft<T: Storage> {
 
     pub is_learner: bool,
 
-    pub votes: FlatMap<u64, bool>,
+    pub votes: FxHashMap<u64, bool>,
 
     pub msgs: Vec<Message>,
 
@@ -650,7 +650,7 @@ impl<T: Storage> Raft<T> {
 
         self.abort_leader_transfer();
 
-        self.votes = FlatMap::default();
+        self.votes = FxHashMap::default();
 
         self.pending_conf_index = 0;
         self.read_only = ReadOnly::new(self.read_only.option);

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -29,7 +29,7 @@ use std::collections::VecDeque;
 
 use eraftpb::Message;
 
-use fnv::{FnvHashMap, FnvHashSet};
+use fxhash::{FxHashMap, FxHashSet};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ReadOnlyOption {
@@ -65,13 +65,13 @@ pub struct ReadState {
 pub struct ReadIndexStatus {
     pub req: Message,
     pub index: u64,
-    pub acks: FnvHashSet<u64>,
+    pub acks: FxHashSet<u64>,
 }
 
 #[derive(Default, Debug, Clone)]
 pub struct ReadOnly {
     pub option: ReadOnlyOption,
-    pub pending_read_index: FnvHashMap<Vec<u8>, ReadIndexStatus>,
+    pub pending_read_index: FxHashMap<Vec<u8>, ReadIndexStatus>,
     pub read_index_queue: VecDeque<Vec<u8>>,
 }
 
@@ -79,7 +79,7 @@ impl ReadOnly {
     pub fn new(option: ReadOnlyOption) -> ReadOnly {
         ReadOnly {
             option: option,
-            pending_read_index: FnvHashMap::default(),
+            pending_read_index: FxHashMap::default(),
             read_index_queue: VecDeque::new(),
         }
     }
@@ -99,7 +99,7 @@ impl ReadOnly {
         let status = ReadIndexStatus {
             req: m,
             index: index,
-            acks: FnvHashSet::default(),
+            acks: FxHashSet::default(),
         };
         self.pending_read_index.insert(ctx.clone(), status);
         self.read_index_queue.push_back(ctx);

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,12 +26,11 @@
 // limitations under the License.
 
 use eraftpb::HardState;
+use fxhash::FxHashMap;
 
 use raft::{Raft, SoftState, StateRole};
 use storage::Storage;
 use progress::Progress;
-
-use flat_map::FlatMap;
 
 #[derive(Default)]
 pub struct Status {
@@ -39,8 +38,8 @@ pub struct Status {
     pub hs: HardState,
     pub ss: SoftState,
     pub applied: u64,
-    pub progress: FlatMap<u64, Progress>,
-    pub learner_progress: FlatMap<u64, Progress>,
+    pub progress: FxHashMap<u64, Progress>,
+    pub learner_progress: FxHashMap<u64, Progress>,
 }
 
 impl Status {


### PR DESCRIPTION
FlatMap sorts keys, which is unnecessary for small groups. A Raft group usually has 3 ~ 5 nodes.