### PR TITLE
*: Introduce slog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,17 @@ description = "The rust language implementation of Raft algorithm."
 categories = ["algorithms", "database-implementations"]
 
 [dependencies]
-log = ">0.2"
+slog = "2.2"
 protobuf = "2.0.4"
 quick-error = "1.2.2"
 rand = "0.5.4"
 fxhash = "0.2.1"
+slog-async = "2.3.0"
+slog-stdlog = "3.0.2"
+slog-term = "2.4.0"
+slog-envlogger = "2.1.0"
 
 [dev-dependencies]
-env_logger = "0.5"
 criterion = ">0.2.4"
 
 [[bench]]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -133,12 +133,10 @@ pub type Result<T> = result::Result<T, Error>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use setup_for_test;
     use std::io;
 
     #[test]
     fn test_error_equal() {
-        setup_for_test();
         assert_eq!(Error::StepPeerNotFound, Error::StepPeerNotFound);
         assert_eq!(
             Error::Store(StorageError::Compacted),
@@ -177,7 +175,6 @@ mod tests {
 
     #[test]
     fn test_storage_error_equal() {
-        setup_for_test();
         assert_eq!(StorageError::Compacted, StorageError::Compacted);
         assert_eq!(StorageError::Unavailable, StorageError::Unavailable);
         assert_eq!(

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -185,7 +185,7 @@ impl Unstable {
 mod test {
     use eraftpb::{Entry, Snapshot, SnapshotMetadata};
     use log_unstable::Unstable;
-    use setup_for_test;
+    use testing_logger;
 
     fn new_entry(index: u64, term: u64) -> Entry {
         let mut e = Entry::new();
@@ -205,7 +205,7 @@ mod test {
 
     #[test]
     fn test_maybe_first_index() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "maybe_first_index"));
         // entry, offset, snap, wok, windex,
         let tests = vec![
             // no snapshot
@@ -233,7 +233,7 @@ mod test {
 
     #[test]
     fn test_maybe_last_index() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "maybe_last_index"));
         // entry, offset, snap, wok, windex,
         let tests = vec![
             (Some(new_entry(5, 1)), 5, None, true, 5),
@@ -261,7 +261,7 @@ mod test {
 
     #[test]
     fn test_maybe_term() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "maybe_term"));
         // entry, offset, snap, index, wok, wterm
         let tests = vec![
             // term from entries
@@ -323,7 +323,7 @@ mod test {
 
     #[test]
     fn test_restore() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "restore"));
         let mut u = Unstable {
             entries: vec![new_entry(5, 1)],
             offset: 5,
@@ -341,7 +341,7 @@ mod test {
 
     #[test]
     fn test_stable_to() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "stable_to"));
         // entries, offset, snap, index, term, woffset, wlen
         let tests = vec![
             (vec![], 0, None, 5, 1, 0, 0),
@@ -421,7 +421,7 @@ mod test {
 
     #[test]
     fn test_truncate_and_append() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "truncate_and_append"));
         // entries, offset, snap, to_append, woffset, wentries
         let tests = vec![
             // replace to the end

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -31,13 +31,14 @@ use eraftpb::{Entry, EntryType, HardState, Message, MessageType, Snapshot};
 use fxhash::FxHashMap;
 use protobuf::RepeatedField;
 use rand::{self, Rng};
+use slog::{self, Logger};
 
 use super::errors::{Error, Result, StorageError};
 use super::progress::{Inflights, Progress, ProgressSet, ProgressState};
 use super::raft_log::{self, RaftLog};
 use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};
 use super::storage::Storage;
-use super::Config;
+use super::{default_logger, discard_logger, Config};
 
 // CAMPAIGN_PRE_ELECTION represents the first phase of a normal election when
 // Config.pre_vote is true.
@@ -84,7 +85,6 @@ pub struct SoftState {
 
 /// A struct that represents the raft consensus itself. Stores details concerning the current
 /// and possible state the system can take.
-#[derive(Default)]
 pub struct Raft<T: Storage> {
     /// The current election term.
     pub term: u64,
@@ -183,6 +183,48 @@ pub struct Raft<T: Storage> {
 
     /// Tag is only used for logging
     tag: String,
+
+    /// The logger for the raft structure.
+    pub logger: slog::Logger,
+}
+
+impl<T> Default for Raft<T>
+where
+    T: Storage + Default,
+{
+    fn default() -> Self {
+        Raft {
+            term: Default::default(),
+            vote: Default::default(),
+            id: Default::default(),
+            read_states: Default::default(),
+            raft_log: Default::default(),
+            max_inflight: Default::default(),
+            max_msg_size: Default::default(),
+            prs: Default::default(),
+            state: Default::default(),
+            is_learner: Default::default(),
+            votes: Default::default(),
+            msgs: Default::default(),
+            leader_id: Default::default(),
+            lead_transferee: Default::default(),
+            pending_conf_index: Default::default(),
+            read_only: Default::default(),
+            election_elapsed: Default::default(),
+            heartbeat_elapsed: Default::default(),
+            check_quorum: Default::default(),
+            pre_vote: Default::default(),
+            skip_bcast_commit: Default::default(),
+            heartbeat_timeout: Default::default(),
+            election_timeout: Default::default(),
+            min_election_timeout: Default::default(),
+            max_election_timeout: Default::default(),
+            randomized_election_timeout: Default::default(),
+            before_step_state: Default::default(),
+            tag: Default::default(),
+            logger: discard_logger().new(o!()),
+        }
+    }
 }
 
 trait AssertSend: Send {}
@@ -223,11 +265,14 @@ pub fn quorum(total: usize) -> usize {
 
 impl<T: Storage> Raft<T> {
     /// Creates a new raft for use on the node.
-    pub fn new(c: &Config, store: T) -> Raft<T> {
+    pub fn new<'a>(c: &Config, store: T, logger: impl Into<Option<&'a Logger>>) -> Raft<T> {
+        let logger = logger.into().unwrap_or(&default_logger()).new(o!(
+				"id" => c.id,
+			));
         c.validate().expect("configuration is invalid");
         let rs = store.initial_state().expect("");
         let conf_state = &rs.conf_state;
-        let raft_log = RaftLog::new(store, c.tag.clone());
+        let raft_log = RaftLog::new(store, c.tag.clone(), &logger);
         let mut peers: &[u64] = &c.peers;
         let mut learners: &[u64] = &c.learners;
         if !conf_state.get_nodes().is_empty() || !conf_state.get_learners().is_empty() {
@@ -249,7 +294,7 @@ impl<T: Storage> Raft<T> {
             raft_log,
             max_inflight: c.max_inflight_msgs,
             max_msg_size: c.max_size_per_msg,
-            prs: Some(ProgressSet::new(peers.len(), learners.len())),
+            prs: Some(ProgressSet::new(peers.len(), learners.len(), &logger)),
             state: StateRole::Follower,
             is_learner: false,
             check_quorum: c.check_quorum,
@@ -272,6 +317,7 @@ impl<T: Storage> Raft<T> {
             max_election_timeout: c.max_election_tick(),
             skip_bcast_commit: c.skip_bcast_commit,
             tag: c.tag.to_owned(),
+            logger,
         };
         for p in peers {
             let pr = new_progress(1, r.max_inflight);
@@ -299,15 +345,16 @@ impl<T: Storage> Raft<T> {
         let term = r.term;
         r.become_follower(term, INVALID_ID);
         info!(
-            "{} newRaft [peers: {:?}, term: {:?}, commit: {}, applied: {}, last_index: {}, \
-             last_term: {}]",
-            r.tag,
-            r.prs().nodes(),
-            r.term,
-            r.raft_log.committed,
-            r.raft_log.get_applied(),
-            r.raft_log.last_index(),
-            r.raft_log.last_term()
+            r.logger,
+            "{tag} newRaft [peers: {peers}, term: {term}, commit: {commit}, applied: {applied}, last_index: {last_index}, \
+             last_term: {last_term}]",
+            tag = &r.tag,
+            peers = format!("{:?}", r.prs().nodes()),
+            term = r.term,
+            commit = r.raft_log.committed,
+            applied = r.raft_log.get_applied(),
+            last_index = r.raft_log.last_index(),
+            last_term = r.raft_log.last_term(),
         );
         r
     }
@@ -447,8 +494,10 @@ impl<T: Storage> Raft<T> {
     fn prepare_send_snapshot(&mut self, m: &mut Message, pr: &mut Progress, to: u64) -> bool {
         if !pr.recent_active {
             debug!(
-                "{} ignore sending snapshot to {} since it is not recently active",
-                self.tag, to
+                self.logger,
+                "{tag} ignore sending snapshot to {to} since it is not recently active",
+                tag = &self.tag,
+                to = to,
             );
             return false;
         }
@@ -458,9 +507,11 @@ impl<T: Storage> Raft<T> {
         if let Err(e) = snapshot_r {
             if e == Error::Store(StorageError::SnapshotTemporarilyUnavailable) {
                 debug!(
-                    "{} failed to send snapshot to {} because snapshot is temporarily \
+                    self.logger,
+                    "{tag} failed to send snapshot to {to} because snapshot is temporarily \
                      unavailable",
-                    self.tag, to
+                    tag = &self.tag,
+                    to = to,
                 );
                 return false;
             }
@@ -476,20 +527,24 @@ impl<T: Storage> Raft<T> {
         );
         m.set_snapshot(snapshot);
         debug!(
-            "{} [firstindex: {}, commit: {}] sent snapshot[index: {}, term: {}] to {} \
-             [{:?}]",
-            self.tag,
-            self.raft_log.first_index(),
-            self.raft_log.committed,
-            sindex,
-            sterm,
-            to,
-            pr
+            self.logger,
+            "{tag} [firstindex: {first_index}, commit: {committed}] sent snapshot[index: {snapshot_index}, term: {snapshot_term}] to {to} \
+             [{progress}]",
+            tag = &self.tag,
+            first_index = self.raft_log.first_index(),
+            committed = self.raft_log.committed,
+            snapshot_index = sindex,
+            snapshot_term = sterm,
+            to = to,
+            progress = format!("{:?}", pr),
         );
         pr.become_snapshot(sindex);
         debug!(
-            "{} paused sending replication messages to {} [{:?}]",
-            self.tag, to, pr
+            self.logger,
+            "{tag} paused sending replication messages to {to} [{progress}]",
+            tag = &self.tag,
+            to = to,
+            progress = format!("{:?}", pr),
         );
         true
     }
@@ -719,7 +774,12 @@ impl<T: Storage> Raft<T> {
         self.reset(term);
         self.leader_id = leader_id;
         self.state = StateRole::Follower;
-        info!("{} became follower at term {}", self.tag, self.term);
+        info!(
+            self.logger,
+            "{tag} became follower at term {term}",
+            tag = &self.tag,
+            term = self.term
+        );
     }
 
     // TODO: revoke pub when there is a better way to test.
@@ -739,7 +799,12 @@ impl<T: Storage> Raft<T> {
         let id = self.id;
         self.vote = id;
         self.state = StateRole::Candidate;
-        info!("{} became candidate at term {}", self.tag, self.term);
+        info!(
+            self.logger,
+            "{tag} became candidate at term {term}",
+            tag = &self.tag,
+            term = self.term
+        );
     }
 
     /// Converts this node to a pre-candidate
@@ -761,7 +826,12 @@ impl<T: Storage> Raft<T> {
         // If a network partition happens, and leader is in minority partition,
         // it will step down, and become follower without notifying others.
         self.leader_id = INVALID_ID;
-        info!("{} became pre-candidate at term {}", self.tag, self.term);
+        info!(
+            self.logger,
+            "{tag} became pre-candidate at term {term}",
+            tag = &self.tag,
+            term = self.term
+        );
     }
 
     // TODO: revoke pub when there is a better way to test.
@@ -789,7 +859,12 @@ impl<T: Storage> Raft<T> {
         self.pending_conf_index = self.raft_log.last_index();
 
         self.append_entry(&mut [Entry::new()]);
-        info!("{} became leader at term {}", self.tag, self.term);
+        info!(
+            self.logger,
+            "{tag} became leader at term {term}",
+            tag = &self.tag,
+            term = self.term
+        );
     }
 
     fn num_pending_conf(&self, ents: &[Entry]) -> usize {
@@ -829,13 +904,14 @@ impl<T: Storage> Raft<T> {
             .filter(|&id| *id != self_id)
             .for_each(|&id| {
                 info!(
-                    "{} [logterm: {}, index: {}] sent {:?} request to {} at term {}",
-                    self.tag,
-                    self.raft_log.last_term(),
-                    self.raft_log.last_index(),
-                    vote_msg,
-                    id,
-                    self.term
+                    self.logger,
+                    "{tag} [logterm: {log_term}, index: {log_index}] sent {msg} request to {id} at term {term}",
+                    tag = &self.tag,
+                    log_term = self.raft_log.last_term(),
+                    log_index = self.raft_log.last_index(),
+                    msg = format!("{:?}", vote_msg),
+                    id = id,
+                    term = self.term
                 );
                 let mut m = new_message(id, vote_msg, None);
                 m.set_term(term);
@@ -855,13 +931,21 @@ impl<T: Storage> Raft<T> {
     fn poll(&mut self, id: u64, msg_type: MessageType, vote: bool) -> usize {
         if vote {
             info!(
-                "{} received {:?} from {} at term {}",
-                self.tag, msg_type, id, self.term
+                self.logger,
+                "{tag} received {msg_type} from {id} at term {term}",
+                tag = &self.tag,
+                msg_type = format!("{:?}", msg_type),
+                id = id,
+                term = self.term,
             )
         } else {
             info!(
-                "{} received {:?} rejection from {} at term {}",
-                self.tag, msg_type, id, self.term
+                self.logger,
+                "{tag} received {msg_type} rejection from {id} at term {term}",
+                tag = &self.tag,
+                msg_type = format!("{:?}", msg_type),
+                id = id,
+                term = self.term
             )
         }
         self.votes.entry(id).or_insert(vote);
@@ -888,19 +972,20 @@ impl<T: Storage> Raft<T> {
                     // timeout of hearing from a current leader, it does not update its term
                     // or grant its vote
                     info!(
-                        "{} [logterm: {}, index: {}, vote: {}] ignored {:?} vote from \
-                         {} [logterm: {}, index: {}] at term {}: lease is not expired \
-                         (remaining ticks: {})",
-                        self.tag,
-                        self.raft_log.last_term(),
-                        self.raft_log.last_index(),
-                        self.vote,
-                        m.get_msg_type(),
-                        m.get_from(),
-                        m.get_log_term(),
-                        m.get_index(),
-                        self.term,
-                        self.election_timeout - self.election_elapsed
+                        self.logger,
+                        "{tag} [logterm: {log_term}, index: {log_index}, vote: {vote}] ignored {msg_type} vote from \
+                         {from} [logterm: {msg_term}, index: {msg_index}] at term {term}: lease is not expired \
+                         (remaining ticks: {ticks})",
+                        tag = &self.tag,
+                        log_term = self.raft_log.last_term(),
+                        log_index = self.raft_log.last_index(),
+                        vote = self.vote,
+                        msg_type = format!("{:?}", m.get_msg_type()),
+                        from = m.get_from(),
+                        msg_term = m.get_log_term(),
+                        msg_index = m.get_index(),
+                        term = self.term,
+                        ticks = self.election_timeout - self.election_elapsed,
                     );
 
                     return Ok(());
@@ -921,12 +1006,13 @@ impl<T: Storage> Raft<T> {
                 // term.
             } else {
                 info!(
-                    "{} [term: {}] received a {:?} message with higher term from {} [term: {}]",
-                    self.tag,
-                    self.term,
-                    m.get_msg_type(),
-                    m.get_from(),
-                    m.get_term()
+                    self.logger,
+                    "{tag} [term: {term}] received a {msg_type} message with higher term from {from} [term: {msg_term}]",
+                    tag = &self.tag,
+                    term = self.term,
+                    msg_type = format!("{:?}", m.get_msg_type()),
+                    from = m.get_from(),
+                    msg_term = m.get_term()
                 );
                 if m.get_msg_type() == MessageType::MsgAppend
                     || m.get_msg_type() == MessageType::MsgHeartbeat
@@ -970,6 +1056,7 @@ impl<T: Storage> Raft<T> {
                 // but less log. After update to pre_vote, the cluster may deadlock if
                 // we drop messages with a lower term.
                 info!(
+                    self.logger,
                     "{} [log_term: {}, index: {}, vote: {}] rejected {:?} from {} [log_term: {}, index: {}] at term {}",
                     self.id,
                     self.raft_log.last_term(),
@@ -990,12 +1077,13 @@ impl<T: Storage> Raft<T> {
             } else {
                 // ignore other cases
                 info!(
-                    "{} [term: {}] ignored a {:?} message with lower term from {} [term: {}]",
-                    self.tag,
-                    self.term,
-                    m.get_msg_type(),
-                    m.get_from(),
-                    m.get_term()
+                    self.logger,
+                    "{tag} [term: {term}] ignored a {msg_type} message with lower term from {from} [term: {msg_term}]",
+                    tag = &self.tag,
+                    term = self.term,
+                    msg_type = format!("{:?}", m.get_msg_type()),
+                    from = m.get_from(),
+                    msg_term = m.get_term()
                 );
             }
             return Ok(());
@@ -1021,15 +1109,20 @@ impl<T: Storage> Raft<T> {
                 let n = self.num_pending_conf(&ents);
                 if n != 0 && self.raft_log.committed > self.raft_log.applied {
                     warn!(
-                        "{} cannot campaign at term {} since there are still {} pending \
+                        self.logger,
+                        "{tag} cannot campaign at term {term} since there are still {pending_changes} pending \
                          configuration changes to apply",
-                        self.tag, self.term, n
+                        tag = &self.tag,
+                        term = self.term,
+                        pending_changes = n,
                     );
                     return Ok(());
                 }
                 info!(
-                    "{} is starting a new election at term {}",
-                    self.tag, self.term
+                    self.logger,
+                    "{tag} is starting a new election at term {term}",
+                    tag = &self.tag,
+                    term = self.term,
                 );
                 if self.pre_vote {
                     self.campaign(CAMPAIGN_PRE_ELECTION);
@@ -1037,7 +1130,11 @@ impl<T: Storage> Raft<T> {
                     self.campaign(CAMPAIGN_ELECTION);
                 }
             } else {
-                debug!("{} ignoring MsgHup because already leader", self.tag);
+                debug!(
+                    self.logger,
+                    "{tag} ignoring MsgHup because already leader",
+                    tag = &self.tag
+                );
             },
             MessageType::MsgRequestVote | MessageType::MsgRequestPreVote => {
                 // We can vote if this is a repeat of a vote we've already cast...
@@ -1089,33 +1186,35 @@ impl<T: Storage> Raft<T> {
 
     fn log_vote_approve(&self, m: &Message) {
         info!(
-            "{} [logterm: {}, index: {}, vote: {}] cast {:?} for {} [logterm: {}, index: {}] \
-             at term {}",
-            self.tag,
-            self.raft_log.last_term(),
-            self.raft_log.last_index(),
-            self.vote,
-            m.get_msg_type(),
-            m.get_from(),
-            m.get_log_term(),
-            m.get_index(),
-            self.term
+            self.logger,
+            "{tag} [logterm: {log_term}, index: {log_index}, vote: {vote}] cast {msg_type} for {from} [logterm: {msg_term}, index: {msg_index}] \
+             at term {term}",
+            tag = &self.tag,
+            log_term = self.raft_log.last_term(),
+            log_index = self.raft_log.last_index(),
+            vote = self.vote,
+            msg_type = format!("{:?}", m.get_msg_type()),
+            from = m.get_from(),
+            msg_term = m.get_log_term(),
+            msg_index = m.get_index(),
+            term = self.term
         );
     }
 
     fn log_vote_reject(&self, m: &Message) {
         info!(
-            "{} [logterm: {}, index: {}, vote: {}] rejected {:?} from {} [logterm: {}, index: \
-             {}] at term {}",
-            self.tag,
-            self.raft_log.last_term(),
-            self.raft_log.last_index(),
-            self.vote,
-            m.get_msg_type(),
-            m.get_from(),
-            m.get_log_term(),
-            m.get_index(),
-            self.term
+            self.logger,
+            "{tag} [logterm: {log_term}, index: {log_index}, vote: {vote}] rejected {msg_type} from {from} [logterm: {msg_term}, index: \
+             {msg_index}] at term {term}",
+            tag = &self.tag,
+            log_term = self.raft_log.last_term(),
+            log_index = self.raft_log.last_index(),
+            vote = self.vote,
+            msg_type = format!("{:?}", m.get_msg_type()),
+            from = m.get_from(),
+            msg_term = m.get_log_term(),
+            msg_index = m.get_index(),
+            term = self.term,
         );
     }
 
@@ -1132,19 +1231,21 @@ impl<T: Storage> Raft<T> {
 
         if m.get_reject() {
             debug!(
-                "{} received msgAppend rejection(lastindex: {}) from {} for index {}",
-                self.tag,
-                m.get_reject_hint(),
-                m.get_from(),
-                m.get_index()
+                self.logger,
+                "{tag} received msgAppend rejection(lastindex: {last_index}) from {from} for index {index}",
+                tag = &self.tag,
+                last_index = m.get_reject_hint(),
+                from = m.get_from(),
+                index = m.get_index(),
             );
 
             if pr.maybe_decr_to(m.get_index(), m.get_reject_hint()) {
                 debug!(
-                    "{} decreased progress of {} to [{:?}]",
-                    self.tag,
-                    m.get_from(),
-                    pr
+                    self.logger,
+                    "{tag} decreased progress of {from} to [{progress}]",
+                    tag = &self.tag,
+                    from = m.get_from(),
+                    progress = format!("{:?}", pr),
                 );
                 if pr.state == ProgressState::Replicate {
                     pr.become_probe();
@@ -1164,9 +1265,10 @@ impl<T: Storage> Raft<T> {
             let last_index = self.raft_log.last_index();
             if m.get_from() == lead_transferee && pr.matched == last_index {
                 info!(
-                    "{} sent MsgTimeoutNow to {} after received MsgAppResp",
-                    self.tag,
-                    m.get_from()
+                    self.logger,
+                    "{tag} sent MsgTimeoutNow to {from} after received MsgAppResp",
+                    tag = &self.tag,
+                    from = m.get_from(),
                 );
                 self.send_timeout_now(m.get_from());
             }
@@ -1179,11 +1281,12 @@ impl<T: Storage> Raft<T> {
                     return;
                 }
                 debug!(
-                    "{} snapshot aborted, resumed sending replication messages to {} \
-                     [{:?}]",
-                    self.tag,
-                    m.get_from(),
-                    pr
+                    self.logger,
+                    "{tag} snapshot aborted, resumed sending replication messages to {from} \
+                     [{progress}]",
+                    tag = &self.tag,
+                    from = m.get_from(),
+                    progress = format!("{:?}", pr),
                 );
                 pr.become_probe();
             }
@@ -1243,7 +1346,11 @@ impl<T: Storage> Raft<T> {
 
     fn handle_transfer_leader(&mut self, m: &Message, pr: &mut Progress) {
         if self.is_learner {
-            debug!("{} is learner. Ignored transferring leadership", self.tag);
+            debug!(
+                self.logger,
+                "{tag} is learner. Ignored transferring leadership",
+                tag = &self.tag
+            );
             return;
         }
 
@@ -1252,31 +1359,39 @@ impl<T: Storage> Raft<T> {
         if last_lead_transferee.is_some() {
             if last_lead_transferee.unwrap() == lead_transferee {
                 info!(
-                    "{} [term {}] transfer leadership to {} is in progress, ignores request \
-                     to same node {}",
-                    self.tag, self.term, lead_transferee, lead_transferee
+                    self.logger,
+                    "{tag} [term {term}] transfer leadership to {lead_transferee} is in progress, ignores request \
+                     to same node {lead_transferee}",
+                    tag = &self.tag,
+                    term = self.term,
+                    lead_transferee = lead_transferee,
                 );
                 return;
             }
             self.abort_leader_transfer();
             info!(
-                "{} [term {}] abort previous transferring leadership to {}",
-                self.tag,
-                self.term,
-                last_lead_transferee.unwrap()
+                self.logger,
+                "{tag} [term {term}] abort previous transferring leadership to {last_lead_transferee}",
+                tag = &self.tag,
+                term = self.term,
+                last_lead_transferee = last_lead_transferee.unwrap(),
             );
         }
         if lead_transferee == self.id {
             debug!(
-                "{} is already leader. Ignored transferring leadership to self",
-                self.tag
+                self.logger,
+                "{tag} is already leader. Ignored transferring leadership to self",
+                tag = &self.tag,
             );
             return;
         }
         // Transfer leadership to third party.
         info!(
-            "{} [term {}] starts to transfer leadership to {}",
-            self.tag, self.term, lead_transferee
+            self.logger,
+            "{tag} [term {term}] starts to transfer leadership to {lead_transferee}",
+            tag = &self.tag,
+            term = self.term,
+            lead_transferee = lead_transferee
         );
         // Transfer leadership should be finished in one electionTimeout
         // so reset r.electionElapsed.
@@ -1285,8 +1400,10 @@ impl<T: Storage> Raft<T> {
         if pr.matched == self.raft_log.last_index() {
             self.send_timeout_now(lead_transferee);
             info!(
-                "{} sends MsgTimeoutNow to {} immediately as {} already has up-to-date log",
-                self.tag, lead_transferee, lead_transferee
+                self.logger,
+                "{tag} sends MsgTimeoutNow to {lead_transferee} immediately as {lead_transferee} already has up-to-date log",
+                tag = &self.tag,
+                lead_transferee = lead_transferee,
             );
         } else {
             self.send_append(lead_transferee, pr);
@@ -1298,18 +1415,20 @@ impl<T: Storage> Raft<T> {
             pr.snapshot_failure();
             pr.become_probe();
             debug!(
-                "{} snapshot failed, resumed sending replication messages to {} [{:?}]",
-                self.tag,
-                m.get_from(),
-                pr
+                self.logger,
+                "{tag} snapshot failed, resumed sending replication messages to {from} [{progress}]",
+                tag = &self.tag,
+                from = m.get_from(),
+                progress = format!("{:?}", pr),
             );
         } else {
             pr.become_probe();
             debug!(
-                "{} snapshot succeeded, resumed sending replication messages to {} [{:?}]",
-                self.tag,
-                m.get_from(),
-                pr
+                self.logger,
+                "{tag} snapshot succeeded, resumed sending replication messages to {from} [{progress}]",
+                tag = &self.tag,
+                from = m.get_from(),
+                progress = format!("{:?}", pr),
             );
         }
         // If snapshot finish, wait for the msgAppResp from the remote node before sending
@@ -1328,7 +1447,12 @@ impl<T: Storage> Raft<T> {
         more_to_send: &mut Option<Message>,
     ) {
         if self.prs().get(m.get_from()).is_none() {
-            debug!("{} no progress available for {}", self.tag, m.get_from());
+            debug!(
+                self.logger,
+                "{} no progress available for {}",
+                tag = &self.tag,
+                from = m.get_from(),
+            );
             return;
         }
 
@@ -1355,10 +1479,11 @@ impl<T: Storage> Raft<T> {
                     pr.become_probe();
                 }
                 debug!(
-                    "{} failed to send message to {} because it is unreachable [{:?}]",
-                    self.tag,
-                    m.get_from(),
-                    pr
+                    self.logger,
+                    "{tag} failed to send message to {from} because it is unreachable [{progress}]",
+                    tag = &self.tag,
+                    from = m.get_from(),
+                    progress = format!("{:?}", pr),
                 );
             }
             MessageType::MsgTransferLeader => {
@@ -1380,8 +1505,9 @@ impl<T: Storage> Raft<T> {
             MessageType::MsgCheckQuorum => {
                 if !self.check_quorum_active() {
                     warn!(
-                        "{} stepped down to follower since quorum is not active",
-                        self.tag
+                        self.logger,
+                        "{tag} stepped down to follower since quorum is not active",
+                        tag = &self.tag
                     );
                     let term = self.term;
                     self.become_follower(term, INVALID_ID);
@@ -1390,7 +1516,7 @@ impl<T: Storage> Raft<T> {
             }
             MessageType::MsgPropose => {
                 if m.get_entries().is_empty() {
-                    panic!("{} stepped empty MsgProp", self.tag);
+                    panic!("{} stepped empty MsgProp", &self.tag);
                 }
                 if !self.prs().voters().contains_key(&self.id) {
                     // If we are not currently a member of the range (i.e. this node
@@ -1400,11 +1526,12 @@ impl<T: Storage> Raft<T> {
                 }
                 if self.lead_transferee.is_some() {
                     debug!(
-                        "{} [term {}] transfer leadership to {} is in progress; dropping \
+                        self.logger,
+                        "{tag} [term {term}] transfer leadership to {lead_transferee} is in progress; dropping \
                          proposal",
-                        self.tag,
-                        self.term,
-                        self.lead_transferee.unwrap()
+                        tag = &self.tag,
+                        term = self.term,
+                        lead_transferee = self.lead_transferee.unwrap(),
                     );
                     return Err(Error::ProposalDropped);
                 }
@@ -1413,9 +1540,12 @@ impl<T: Storage> Raft<T> {
                     if e.get_entry_type() == EntryType::EntryConfChange {
                         if self.has_pending_conf() {
                             info!(
-                                "propose conf {:?} ignored since pending unapplied \
-                                 configuration [index {}, applied {}]",
-                                e, self.pending_conf_index, self.raft_log.applied
+                                self.logger,
+                                "propose conf {entry} ignored since pending unapplied \
+                                 configuration [index {index}, applied {applied}]",
+                                entry = format!("{:?}", e),
+                                index = self.pending_conf_index,
+                                applied = self.raft_log.applied,
                             );
                             *e = Entry::new();
                             e.set_entry_type(EntryType::EntryNormal);
@@ -1522,8 +1652,10 @@ impl<T: Storage> Raft<T> {
         match m.get_msg_type() {
             MessageType::MsgPropose => {
                 info!(
-                    "{} no leader at term {}; dropping proposal",
-                    self.tag, self.term
+                    self.logger,
+                    "{tag} no leader at term {term}; dropping proposal",
+                    tag = &self.tag,
+                    term = self.term
                 );
                 return Err(Error::ProposalDropped);
             }
@@ -1556,12 +1688,13 @@ impl<T: Storage> Raft<T> {
 
                 let gr = self.poll(m.get_from(), m.get_msg_type(), !m.get_reject());
                 info!(
-                    "{} [quorum:{}] has received {} {:?} votes and {} vote rejections",
-                    self.tag,
-                    self.quorum(),
-                    gr,
-                    m.get_msg_type(),
-                    self.votes.len() - gr
+                    self.logger,
+                    "{tag} [quorum:{qourum}] has received {votes} {msg_type} votes and {rejections} vote rejections",
+                    tag = &self.tag,
+                    qourum = self.quorum(),
+                    votes = gr,
+                    msg_type = format!("{:?}", m.get_msg_type()),
+                    rejections = self.votes.len() - gr,
                 );
                 if self.quorum() == gr {
                     if self.state == StateRole::PreCandidate {
@@ -1578,11 +1711,12 @@ impl<T: Storage> Raft<T> {
                 }
             }
             MessageType::MsgTimeoutNow => debug!(
-                "{} [term {} state {:?}] ignored MsgTimeoutNow from {}",
-                self.tag,
-                self.term,
-                self.state,
-                m.get_from()
+                self.logger,
+                "{tag} [term {term} state {state}] ignored MsgTimeoutNow from {from}",
+                tag = &self.tag,
+                term = self.term,
+                state = format!("{:?}", self.state),
+                from = m.get_from(),
             ),
             _ => {}
         }
@@ -1594,8 +1728,10 @@ impl<T: Storage> Raft<T> {
             MessageType::MsgPropose => {
                 if self.leader_id == INVALID_ID {
                     info!(
-                        "{} no leader at term {}; dropping proposal",
-                        self.tag, self.term
+                        self.logger,
+                        "{tag} no leader at term {term}; dropping proposal",
+                        tag = &self.tag,
+                        term = self.term
                     );
                     return Err(Error::ProposalDropped);
                 }
@@ -1620,8 +1756,10 @@ impl<T: Storage> Raft<T> {
             MessageType::MsgTransferLeader => {
                 if self.leader_id == INVALID_ID {
                     info!(
-                        "{} no leader at term {}; dropping leader transfer msg",
-                        self.tag, self.term
+                        self.logger,
+                        "{tag} no leader at term {term}; dropping leader transfer msg",
+                        tag = &self.tag,
+                        term = self.term,
                     );
                     return Ok(());
                 }
@@ -1631,11 +1769,12 @@ impl<T: Storage> Raft<T> {
             MessageType::MsgTimeoutNow => {
                 if self.promotable() {
                     info!(
-                        "{} [term {}] received MsgTimeoutNow from {} and starts an election to \
+                        self.logger,
+                        "{tag} [term {term}] received MsgTimeoutNow from {from} and starts an election to \
                          get leadership.",
-                        self.tag,
-                        self.term,
-                        m.get_from()
+                        tag = &self.tag,
+                        term = self.term,
+                        from = m.get_from(),
                     );
                     // Leadership transfers never use pre-vote even if self.pre_vote is true; we
                     // know we are not recovering from a partition so there is no need for the
@@ -1643,17 +1782,20 @@ impl<T: Storage> Raft<T> {
                     self.campaign(CAMPAIGN_TRANSFER);
                 } else {
                     info!(
-                        "{} received MsgTimeoutNow from {} but is not promotable",
-                        self.tag,
-                        m.get_from()
+                        self.logger,
+                        "{tag} received MsgTimeoutNow from {from} but is not promotable",
+                        tag = &self.tag,
+                        from = m.get_from()
                     );
                 }
             }
             MessageType::MsgReadIndex => {
                 if self.leader_id == INVALID_ID {
                     info!(
-                        "{} no leader at term {}; dropping index reading msg",
-                        self.tag, self.term
+                        self.logger,
+                        "{tag} no leader at term {term}; dropping index reading msg",
+                        tag = &self.tag,
+                        term = self.term,
                     );
                     return Ok(());
                 }
@@ -1663,10 +1805,11 @@ impl<T: Storage> Raft<T> {
             MessageType::MsgReadIndexResp => {
                 if m.get_entries().len() != 1 {
                     error!(
-                        "{} invalid format of MsgReadIndexResp from {}, entries count: {}",
-                        self.tag,
-                        m.get_from(),
-                        m.get_entries().len()
+                        self.logger,
+                        "{tag} invalid format of MsgReadIndexResp from {from}, entries count: {count}",
+                        tag = &self.tag,
+                        from = m.get_from(),
+                        count = m.get_entries().len(),
                     );
                     return Ok(());
                 }
@@ -1707,14 +1850,15 @@ impl<T: Storage> Raft<T> {
             }
             None => {
                 debug!(
-                    "{} [logterm: {}, index: {}] rejected msgApp [logterm: {}, index: {}] \
-                     from {}",
-                    self.tag,
-                    self.raft_log.term(m.get_index()).unwrap_or(0),
-                    m.get_index(),
-                    m.get_log_term(),
-                    m.get_index(),
-                    m.get_from()
+                    self.logger,
+                    "{tag} [logterm: {term}, index: {index}] rejected msgApp [logterm: {msg_log_term}, index: {msg_index}] \
+                     from {from}",
+                    tag = &self.tag,
+                    term = self.raft_log.term(m.get_index()).unwrap_or(0),
+                    index = m.get_index(),
+                    msg_log_term = m.get_log_term(),
+                    msg_index = m.get_index(),
+                    from = m.get_from()
                 );
                 to_send.set_index(m.get_index());
                 to_send.set_reject(true);
@@ -1742,8 +1886,12 @@ impl<T: Storage> Raft<T> {
         );
         if self.restore(m.take_snapshot()) {
             info!(
-                "{} [commit: {}] restored snapshot [index: {}, term: {}]",
-                self.tag, self.raft_log.committed, sindex, sterm
+                self.logger,
+                "{tag} [commit: {commit}] restored snapshot [index: {snapshot_index}, term: {snapshot_term}]",
+                tag = &self.tag,
+                commit = self.raft_log.committed,
+                snapshot_index = sindex,
+                snapshot_term = sterm
             );
             let mut to_send = Message::new();
             to_send.set_to(m.get_from());
@@ -1752,8 +1900,12 @@ impl<T: Storage> Raft<T> {
             self.send(to_send);
         } else {
             info!(
-                "{} [commit: {}] ignored snapshot [index: {}, term: {}]",
-                self.tag, self.raft_log.committed, sindex, sterm
+                self.logger,
+                "{tag} [commit: {commit}] ignored snapshot [index: {snapshot_index}, term: {snapshot_term}]",
+                tag = &self.tag,
+                commit = self.raft_log.committed,
+                snapshot_index = sindex,
+                snapshot_term = sterm,
             );
             let mut to_send = Message::new();
             to_send.set_to(m.get_from());
@@ -1767,14 +1919,15 @@ impl<T: Storage> Raft<T> {
         let meta = snap.get_metadata();
         if self.raft_log.match_term(meta.get_index(), meta.get_term()) {
             info!(
-                "{} [commit: {}, lastindex: {}, lastterm: {}] fast-forwarded commit to \
-                 snapshot [index: {}, term: {}]",
-                self.tag,
-                self.raft_log.committed,
-                self.raft_log.last_index(),
-                self.raft_log.last_term(),
-                meta.get_index(),
-                meta.get_term()
+                self.logger,
+                "{tag} [commit: {commit}, lastindex: {last_index}, lastterm: {last_term}] fast-forwarded commit to \
+                 snapshot [index: {snapshot_index}, term: {snapshot_term}]",
+                tag = &self.tag,
+                commit = self.raft_log.committed,
+                last_index = self.raft_log.last_index(),
+                last_term = self.raft_log.last_term(),
+                snapshot_index = meta.get_index(),
+                snapshot_term = meta.get_term()
             );
             self.raft_log.commit_to(meta.get_index());
             return Some(false);
@@ -1787,10 +1940,11 @@ impl<T: Storage> Raft<T> {
             for &id in meta.get_conf_state().get_learners() {
                 if id == self.id {
                     error!(
-                        "{} can't become learner when restores snapshot [index: {}, term: {}]",
-                        self.tag,
-                        meta.get_index(),
-                        meta.get_term(),
+                        self.logger,
+                        "{tag} can't become learner when restores snapshot [index: {snapshot_index}, term: {snapshot_term}]",
+                        tag = &self.tag,
+                        snapshot_index = meta.get_index(),
+                        snapshot_term = meta.get_term(),
                     );
                     return Some(false);
                 }
@@ -1798,19 +1952,20 @@ impl<T: Storage> Raft<T> {
         }
 
         info!(
-            "{} [commit: {}, lastindex: {}, lastterm: {}] starts to restore snapshot \
-             [index: {}, term: {}]",
-            self.tag,
-            self.raft_log.committed,
-            self.raft_log.last_index(),
-            self.raft_log.last_term(),
-            meta.get_index(),
-            meta.get_term()
+            self.logger,
+            "{tag} [commit: {commit}, lastindex: {last_index}, lastterm: {last_term}] starts to restore snapshot \
+             [index: {snapshot_index}, term: {snapshot_term}]",
+            tag = &self.tag,
+            commit = self.raft_log.committed,
+            last_index = self.raft_log.last_index(),
+            last_term = self.raft_log.last_term(),
+            snapshot_index = meta.get_index(),
+            snapshot_term = meta.get_term(),
         );
 
         let nodes = meta.get_conf_state().get_nodes();
         let learners = meta.get_conf_state().get_learners();
-        self.prs = Some(ProgressSet::new(nodes.len(), learners.len()));
+        self.prs = Some(ProgressSet::new(nodes.len(), learners.len(), &self.logger));
 
         for &(is_learner, nodes) in &[(false, nodes), (true, learners)] {
             for &n in nodes {
@@ -1822,10 +1977,11 @@ impl<T: Storage> Raft<T> {
                 }
                 self.set_progress(n, matched, next_index, is_learner);
                 info!(
-                    "{} restored progress of {} [{:?}]",
-                    self.tag,
-                    n,
-                    self.prs().get(n)
+                    self.logger,
+                    "{tag} restored progress of {node} [{peer}]",
+                    tag = &self.tag,
+                    node = n,
+                    peer = format!("{:?}", self.prs().get(n)),
                 );
             }
         }
@@ -1869,8 +2025,10 @@ impl<T: Storage> Raft<T> {
         if self.prs().voters().contains_key(&id) {
             if is_learner {
                 info!(
-                    "{} ignored add learner: do not support changing {} from voter to learner",
-                    self.tag, id
+                    self.logger,
+                    "{tag} ignored add learner: do not support changing {id} from voter to learner",
+                    tag = &self.tag,
+                    id = id,
                 );
             }
             // Ignore redundant add voter.
@@ -1992,8 +2150,12 @@ impl<T: Storage> Raft<T> {
         let timeout =
             rand::thread_rng().gen_range(self.min_election_timeout, self.max_election_timeout);
         debug!(
-            "{} reset election timeout {} -> {} at {}",
-            self.tag, prev_timeout, timeout, self.election_elapsed
+            self.logger,
+            "{tag} reset election timeout {prev_timeout} -> {timeout} at {election_elapsed}",
+            tag = &self.tag,
+            prev_timeout = prev_timeout,
+            timeout = timeout,
+            election_elapsed = self.election_elapsed
         );
         self.randomized_election_timeout = timeout;
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -324,8 +324,8 @@ mod test {
     use protobuf;
 
     use errors::{Error as RaftError, StorageError};
-    use setup_for_test;
     use storage::{MemStorage, Storage};
+    use testing_logger;
 
     // TODO extract these duplicated utility functions for tests
 
@@ -351,7 +351,7 @@ mod test {
 
     #[test]
     fn test_storage_term() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_term"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![
             (2, Err(RaftError::Store(StorageError::Compacted))),
@@ -374,7 +374,7 @@ mod test {
 
     #[test]
     fn test_storage_entries() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_entries"));
         let ents = vec![
             new_entry(3, 3),
             new_entry(4, 4),
@@ -444,7 +444,7 @@ mod test {
 
     #[test]
     fn test_storage_last_index() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_last_index"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let storage = MemStorage::new();
         storage.wl().entries = ents;
@@ -468,7 +468,7 @@ mod test {
 
     #[test]
     fn test_storage_first_index() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_first_index"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let storage = MemStorage::new();
         storage.wl().entries = ents;
@@ -489,7 +489,7 @@ mod test {
 
     #[test]
     fn test_storage_compact() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_compact"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![
             (2, Err(RaftError::Store(StorageError::Compacted)), 3, 3, 3),
@@ -522,7 +522,7 @@ mod test {
 
     #[test]
     fn test_storage_create_snapshot() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_create_snapshot"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let nodes = vec![1, 2, 3];
         let mut cs = ConfState::new();
@@ -550,7 +550,7 @@ mod test {
 
     #[test]
     fn test_storage_append() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_append"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![
             (
@@ -619,7 +619,7 @@ mod test {
 
     #[test]
     fn test_storage_apply_snapshot() {
-        setup_for_test();
+        let l = testing_logger().new(o!("test" => "storage_apply_snapshot"));
         let nodes = vec![1, 2, 3];
         let data = b"data".to_vec();
 

--- a/tests/cases/test_raft_flow_control.rs
+++ b/tests/cases/test_raft_flow_control.rs
@@ -27,15 +27,15 @@
 
 use super::test_raft::*;
 use raft::eraftpb::*;
-use setup_for_test;
+use testing_logger;
 
 // test_msg_app_flow_control_full ensures:
 // 1. msgApp can fill the sending window until full
 // 2. when the window is full, no more msgApp can be sent.
 #[test]
 fn test_msg_app_flow_control_full() {
-    setup_for_test();
-    let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "msg_app_flow_control_full"));
+    let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
 
@@ -71,8 +71,8 @@ fn test_msg_app_flow_control_full() {
 // 2. out-of-dated msgAppResp has no effect on the sliding window.
 #[test]
 fn test_msg_app_flow_control_move_forward() {
-    setup_for_test();
-    let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "msg_app_flow_control_move_forward"));
+    let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
 
@@ -125,8 +125,8 @@ fn test_msg_app_flow_control_move_forward() {
 // frees one slot if the window is full.
 #[test]
 fn test_msg_app_flow_control_recv_heartbeat() {
-    setup_for_test();
-    let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "msg_app_flow_control_recv_heartbeat"));
+    let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
 

--- a/tests/cases/test_raft_paper.rs
+++ b/tests/cases/test_raft_paper.rs
@@ -30,7 +30,8 @@ use protobuf::RepeatedField;
 use raft::eraftpb::*;
 use raft::storage::MemStorage;
 use raft::*;
-use setup_for_test;
+use slog::Logger;
+use testing_logger;
 
 pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {
     let mut hs = HardState::new();
@@ -72,20 +73,20 @@ fn accept_and_reply(m: &Message) -> Message {
 
 #[test]
 fn test_follower_update_term_from_message() {
-    setup_for_test();
-    test_update_term_from_message(StateRole::Follower);
+    let l = testing_logger().new(o!("test" => "candidate_update_term_from_message"));
+    test_update_term_from_message(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidate_update_term_from_message() {
-    setup_for_test();
-    test_update_term_from_message(StateRole::Candidate);
+    let l = testing_logger().new(o!("test" => "candidate_update_term_from_message"));
+    test_update_term_from_message(StateRole::Candidate, &l);
 }
 
 #[test]
 fn test_leader_update_term_from_message() {
-    setup_for_test();
-    test_update_term_from_message(StateRole::Leader);
+    let l = testing_logger().new(o!("test" => "leader_update_term_from_message"));
+    test_update_term_from_message(StateRole::Leader, &l);
 }
 
 // test_update_term_from_message tests that if one server’s current term is
@@ -93,8 +94,8 @@ fn test_leader_update_term_from_message() {
 // value. If a candidate or leader discovers that its term is out of date,
 // it immediately reverts to follower state.
 // Reference: section 5.1
-fn test_update_term_from_message(state: StateRole) {
-    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+fn test_update_term_from_message(state: StateRole, l: &Logger) {
+    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     match state {
         StateRole::Follower => r.become_follower(1, 2),
         StateRole::PreCandidate => r.become_pre_candidate(),
@@ -119,8 +120,8 @@ fn test_update_term_from_message(state: StateRole) {
 // Reference: section 5.1
 #[test]
 fn test_reject_stale_term_message() {
-    setup_for_test();
-    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "reject_stale_term_message"));
+    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let panic_before_step_state =
         Box::new(|_: &Message| panic!("before step state function hook called unexpectedly"));
     r.before_step_state = Some(panic_before_step_state);
@@ -135,8 +136,8 @@ fn test_reject_stale_term_message() {
 // Reference: section 5.2
 #[test]
 fn test_start_as_follower() {
-    setup_for_test();
-    let r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "start_as_follower"));
+    let r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     assert_eq!(r.state, StateRole::Follower);
 }
 
@@ -146,10 +147,10 @@ fn test_start_as_follower() {
 // Reference: section 5.2
 #[test]
 fn test_leader_bcast_beat() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_bcast_beat"));
     // heartbeat interval
     let hi = 1;
-    let mut r = new_test_raft(1, vec![1, 2, 3], 10, hi, new_storage());
+    let mut r = new_test_raft(1, vec![1, 2, 3], 10, hi, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
     for i in 0..10 {
@@ -176,14 +177,14 @@ fn test_leader_bcast_beat() {
 
 #[test]
 fn test_follower_start_election() {
-    setup_for_test();
-    test_nonleader_start_election(StateRole::Follower);
+    let l = testing_logger().new(o!("test" => "follower_start_election"));
+    test_nonleader_start_election(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidate_start_new_election() {
-    setup_for_test();
-    test_nonleader_start_election(StateRole::Candidate);
+    let l = testing_logger().new(o!("test" => "candidate_start_new_election"));
+    test_nonleader_start_election(StateRole::Candidate, &l);
 }
 
 // test_nonleader_start_election tests that if a follower receives no communication
@@ -196,10 +197,10 @@ fn test_candidate_start_new_election() {
 // start a new election by incrementing its term and initiating another
 // round of RequestVote RPCs.
 // Reference: section 5.2
-fn test_nonleader_start_election(state: StateRole) {
+fn test_nonleader_start_election(state: StateRole, l: &Logger) {
     // election timeout
     let et = 10;
-    let mut r = new_test_raft(1, vec![1, 2, 3], et, 1, new_storage());
+    let mut r = new_test_raft(1, vec![1, 2, 3], et, 1, new_storage(), l);
     match state {
         StateRole::Follower => r.become_follower(1, 2),
         StateRole::Candidate => r.become_candidate(),
@@ -234,7 +235,7 @@ fn test_nonleader_start_election(state: StateRole) {
 // Reference: section 5.2
 #[test]
 fn test_leader_election_in_one_round_rpc() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_election_in_one_round_rpc"));
     let mut tests = vec![
         // win the election when receiving votes from a majority of the servers
         (1, map!(), StateRole::Leader),
@@ -267,7 +268,7 @@ fn test_leader_election_in_one_round_rpc() {
     ];
 
     for (i, (size, votes, state)) in tests.drain(..).enumerate() {
-        let mut r = new_test_raft(1, (1..size as u64 + 1).collect(), 10, 1, new_storage());
+        let mut r = new_test_raft(1, (1..size as u64 + 1).collect(), 10, 1, new_storage(), &l);
 
         r.step(new_message(1, 1, MessageType::MsgHup, 0)).expect("");
         for (id, vote) in votes {
@@ -291,7 +292,7 @@ fn test_leader_election_in_one_round_rpc() {
 // Reference: section 5.2
 #[test]
 fn test_follower_vote() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "follower_vote"));
     let mut tests = vec![
         (INVALID_ID, 1, false),
         (INVALID_ID, 2, false),
@@ -302,7 +303,7 @@ fn test_follower_vote() {
     ];
 
     for (i, (vote, nvote, wreject)) in tests.drain(..).enumerate() {
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
         r.load_state(&hard_state(1, 0, vote));
 
         let mut m = new_message(nvote, 1, MessageType::MsgRequestVote, 0);
@@ -327,7 +328,7 @@ fn test_follower_vote() {
 // Reference: section 5.2
 #[test]
 fn test_candidate_fallback() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "candidate_fallback"));
     let new_message_ext = |f, to, term| {
         let mut m = new_message(f, to, MessageType::MsgAppend, 0);
         m.set_term(term);
@@ -335,7 +336,7 @@ fn test_candidate_fallback() {
     };
     let mut tests = vec![new_message_ext(2, 1, 1), new_message_ext(2, 1, 2)];
     for (i, m) in tests.drain(..).enumerate() {
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
         r.step(new_message(1, 1, MessageType::MsgHup, 0)).expect("");
         assert_eq!(r.state, StateRole::Candidate);
 
@@ -358,22 +359,22 @@ fn test_candidate_fallback() {
 
 #[test]
 fn test_follower_election_timeout_randomized() {
-    setup_for_test();
-    test_non_leader_election_timeout_randomized(StateRole::Follower);
+    let l = testing_logger().new(o!("test" => "follower_election_timeout_randomized"));
+    test_non_leader_election_timeout_randomized(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidate_election_timeout_randomized() {
-    setup_for_test();
-    test_non_leader_election_timeout_randomized(StateRole::Candidate);
+    let l = testing_logger().new(o!("test" => "candidate_election_timeout_randomized"));
+    test_non_leader_election_timeout_randomized(StateRole::Candidate, &l);
 }
 
 // test_non_leader_election_timeout_randomized tests that election timeout for
 // follower or candidate is randomized.
 // Reference: section 5.2
-fn test_non_leader_election_timeout_randomized(state: StateRole) {
+fn test_non_leader_election_timeout_randomized(state: StateRole, l: &Logger) {
     let et = 10;
-    let mut r = new_test_raft(1, vec![1, 2, 3], et, 1, new_storage());
+    let mut r = new_test_raft(1, vec![1, 2, 3], et, 1, new_storage(), l);
     let mut timeouts = map!();
     for _ in 0..1000 * et {
         let term = r.term;
@@ -399,27 +400,27 @@ fn test_non_leader_election_timeout_randomized(state: StateRole) {
 
 #[test]
 fn test_follower_election_timeout_nonconflict() {
-    setup_for_test();
-    test_nonleaders_election_timeout_nonconfict(StateRole::Follower);
+    let l = testing_logger().new(o!("test" => "follower_election_timeoout_nonconflict"));
+    test_nonleaders_election_timeout_nonconfict(StateRole::Follower, &l);
 }
 
 #[test]
-fn test_acandidates_election_timeout_nonconf() {
-    setup_for_test();
-    test_nonleaders_election_timeout_nonconfict(StateRole::Candidate);
+fn test_candidates_election_timeout_nonconf() {
+    let l = testing_logger().new(o!("test" => "candidates_election_timeout_nonconf"));
+    test_nonleaders_election_timeout_nonconfict(StateRole::Candidate, &l);
 }
 
 // test_nonleaders_election_timeout_nonconfict tests that in most cases only a
 // single server(follower or candidate) will time out, which reduces the
 // likelihood of split vote in the new election.
 // Reference: section 5.2
-fn test_nonleaders_election_timeout_nonconfict(state: StateRole) {
+fn test_nonleaders_election_timeout_nonconfict(state: StateRole, l: &Logger) {
     let et = 10;
     let size = 5;
     let mut rs = Vec::with_capacity(size);
     let ids: Vec<u64> = (1..size as u64 + 1).collect();
     for id in ids.iter().take(size) {
-        rs.push(new_test_raft(*id, ids.clone(), et, 1, new_storage()));
+        rs.push(new_test_raft(*id, ids.clone(), et, 1, new_storage(), l));
     }
     let mut conflicts = 0;
     for _ in 0..1000 {
@@ -460,9 +461,9 @@ fn test_nonleaders_election_timeout_nonconfict(state: StateRole) {
 // Reference: section 5.3
 #[test]
 fn test_leader_start_replication() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_start_replication"));
     let s = new_storage();
-    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s.clone());
+    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s.clone(), &l);
     r.become_candidate();
     r.become_leader();
     commit_noop_entry(&mut r, &s);
@@ -502,9 +503,9 @@ fn test_leader_start_replication() {
 // Reference: section 5.3
 #[test]
 fn test_leader_commit_entry() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "commit_entry"));
     let s = new_storage();
-    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s.clone());
+    let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s.clone(), &l);
     r.become_candidate();
     r.become_leader();
     commit_noop_entry(&mut r, &s);
@@ -533,7 +534,7 @@ fn test_leader_commit_entry() {
 // Reference: section 5.3
 #[test]
 fn test_leader_acknowledge_commit() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_acknowledge_commit"));
     let mut tests = vec![
         (1, map!(), true),
         (3, map!(), false),
@@ -547,7 +548,7 @@ fn test_leader_acknowledge_commit() {
     ];
     for (i, (size, acceptors, wack)) in tests.drain(..).enumerate() {
         let s = new_storage();
-        let mut r = new_test_raft(1, (1..size + 1).collect(), 10, 1, s.clone());
+        let mut r = new_test_raft(1, (1..size + 1).collect(), 10, 1, s.clone(), &l);
         r.become_candidate();
         r.become_leader();
         commit_noop_entry(&mut r, &s);
@@ -575,7 +576,7 @@ fn test_leader_acknowledge_commit() {
 // Reference: section 5.3
 #[test]
 fn test_leader_commit_preceding_entries() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_commit_preceding_entries"));
     let mut tests = vec![
         vec![],
         vec![empty_entry(2, 1)],
@@ -586,7 +587,7 @@ fn test_leader_commit_preceding_entries() {
     for (i, mut tt) in tests.drain(..).enumerate() {
         let s = new_storage();
         s.wl().append(&tt).expect("");
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s);
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s, &l);
         r.load_state(&hard_state(2, 0, 0));
         r.become_candidate();
         r.become_leader();
@@ -615,7 +616,7 @@ fn test_leader_commit_preceding_entries() {
 // Reference: section 5.3
 #[test]
 fn test_follower_commit_entry() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "vote_request"));
     let mut tests = vec![
         (vec![new_entry(1, 1, SOME_DATA)], 1),
         (
@@ -642,7 +643,7 @@ fn test_follower_commit_entry() {
     ];
 
     for (i, (ents, commit)) in tests.drain(..).enumerate() {
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
         r.become_follower(1, 2);
 
         let mut m = new_message(2, 1, MessageType::MsgAppend, 0);
@@ -672,7 +673,7 @@ fn test_follower_commit_entry() {
 // Reference: section 5.3
 #[test]
 fn test_follower_check_msg_append() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "follower_check_msg_append"));
     let ents = vec![empty_entry(1, 1), empty_entry(2, 2)];
     let mut tests = vec![
         // match with committed entries
@@ -700,7 +701,7 @@ fn test_follower_check_msg_append() {
     for (i, (term, index, windex, wreject, wreject_hint)) in tests.drain(..).enumerate() {
         let s = new_storage();
         s.wl().append(&ents).expect("");
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s);
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s, &l);
         r.load_state(&hard_state(0, 1, 0));
         r.become_follower(2, 2);
 
@@ -732,7 +733,7 @@ fn test_follower_check_msg_append() {
 // Reference: section 5.3
 #[test]
 fn test_follower_append_entries() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "follower_append_entries"));
     let mut tests = vec![
         (
             2,
@@ -768,7 +769,7 @@ fn test_follower_append_entries() {
         s.wl()
             .append(&[empty_entry(1, 1), empty_entry(2, 2)])
             .expect("");
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s);
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s, &l);
         r.become_follower(2, 2);
 
         let mut m = new_message(2, 1, MessageType::MsgAppend, 0);
@@ -799,7 +800,7 @@ fn test_follower_append_entries() {
 // Reference: section 5.3, figure 7
 #[test]
 fn test_leader_sync_follower_log() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_sync_follower_log"));
     let ents = vec![
         empty_entry(0, 0),
         empty_entry(1, 1),
@@ -891,17 +892,17 @@ fn test_leader_sync_follower_log() {
     for (i, tt) in tests.drain(..).enumerate() {
         let lead_store = new_storage();
         lead_store.wl().append(&ents).expect("");
-        let mut lead = new_test_raft(1, vec![1, 2, 3], 10, 1, lead_store);
+        let mut lead = new_test_raft(1, vec![1, 2, 3], 10, 1, lead_store, &l);
         let last_index = lead.raft_log.last_index();
         lead.load_state(&hard_state(term, last_index, 0));
         let follower_store = new_storage();
         follower_store.wl().append(&tt).expect("");
-        let mut follower = new_test_raft(2, vec![1, 2, 3], 10, 1, follower_store);
+        let mut follower = new_test_raft(2, vec![1, 2, 3], 10, 1, follower_store, &l);
         follower.load_state(&hard_state(term - 1, 0, 0));
         // It is necessary to have a three-node cluster.
         // The second may have more up-to-date log than the first one, so the
         // first node needs the vote from the third node to become the leader.
-        let mut n = Network::new(vec![Some(lead), Some(follower), NOP_STEPPER]);
+        let mut n = Network::new(vec![Some(lead), Some(follower), NOP_STEPPER], &l);
         n.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
         // The election occurs in the term after the one we loaded with
         // lead.load_state above.
@@ -928,13 +929,13 @@ fn test_leader_sync_follower_log() {
 // Reference: section 5.4.1
 #[test]
 fn test_vote_request() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "vote_request"));
     let mut tests = vec![
         (vec![empty_entry(1, 1)], 2),
         (vec![empty_entry(1, 1), empty_entry(2, 2)], 3),
     ];
     for (j, (ents, wterm)) in tests.drain(..).enumerate() {
-        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
+        let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
         let mut m = new_message(2, 1, MessageType::MsgAppend, 0);
         m.set_term(wterm - 1);
         m.set_log_term(0);
@@ -991,7 +992,7 @@ fn test_vote_request() {
 // Reference: section 5.4.1
 #[test]
 fn test_voter() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "voter"));
     let mut tests = vec![
         // same logterm
         (vec![empty_entry(1, 1)], 1, 1, false),
@@ -1009,7 +1010,7 @@ fn test_voter() {
     for (i, (ents, log_term, index, wreject)) in tests.drain(..).enumerate() {
         let s = new_storage();
         s.wl().append(&ents).expect("");
-        let mut r = new_test_raft(1, vec![1, 2], 10, 1, s);
+        let mut r = new_test_raft(1, vec![1, 2], 10, 1, s, &l);
 
         let mut m = new_message(2, 1, MessageType::MsgRequestVote, 0);
         m.set_term(3);
@@ -1045,7 +1046,7 @@ fn test_voter() {
 // Reference: section 5.4.2
 #[test]
 fn test_leader_only_commits_log_from_current_term() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "leader_only_commits_log_from_current_term"));
     let ents = vec![empty_entry(1, 1), empty_entry(2, 2)];
     let mut tests = vec![
         // do not commit log entries in previous terms
@@ -1057,7 +1058,7 @@ fn test_leader_only_commits_log_from_current_term() {
     for (i, (index, wcommit)) in tests.drain(..).enumerate() {
         let store = new_storage();
         store.wl().append(&ents).expect("");
-        let mut r = new_test_raft(1, vec![1, 2], 10, 1, store);
+        let mut r = new_test_raft(1, vec![1, 2], 10, 1, store, &l);
         r.load_state(&hard_state(2, 0, 0));
         // become leader at term 3
         r.become_candidate();

--- a/tests/cases/test_raft_snap.rs
+++ b/tests/cases/test_raft_snap.rs
@@ -27,7 +27,7 @@
 
 use super::test_raft::*;
 use raft::eraftpb::*;
-use setup_for_test;
+use raft::testing_logger;
 
 fn testing_snap() -> Snapshot {
     new_snapshot(11, 11, vec![1, 2])
@@ -35,8 +35,8 @@ fn testing_snap() -> Snapshot {
 
 #[test]
 fn test_sending_snapshot_set_pending_snapshot() {
-    setup_for_test();
-    let mut sm = new_test_raft(1, vec![1], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "sending_snapshot_set_pending_snapshot"));
+    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
     sm.become_candidate();
@@ -55,8 +55,8 @@ fn test_sending_snapshot_set_pending_snapshot() {
 
 #[test]
 fn test_pending_snapshot_pause_replication() {
-    setup_for_test();
-    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "pending_snapshot_pause_replication"));
+    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
     sm.become_candidate();
@@ -71,8 +71,8 @@ fn test_pending_snapshot_pause_replication() {
 
 #[test]
 fn test_snapshot_failure() {
-    setup_for_test();
-    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "snapshot_failure"));
+    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
     sm.become_candidate();
@@ -91,8 +91,8 @@ fn test_snapshot_failure() {
 
 #[test]
 fn test_snapshot_succeed() {
-    setup_for_test();
-    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "snapshot_succeed"));
+    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
     sm.become_candidate();
@@ -111,8 +111,8 @@ fn test_snapshot_succeed() {
 
 #[test]
 fn test_snapshot_abort() {
-    setup_for_test();
-    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "snapshot_abort"));
+    let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
     sm.become_candidate();

--- a/tests/cases/test_raw_node.rs
+++ b/tests/cases/test_raw_node.rs
@@ -31,8 +31,9 @@ use protobuf::{self, ProtobufEnum};
 use raft::eraftpb::*;
 use raft::storage::MemStorage;
 use raft::*;
-use setup_for_test;
+use slog::Logger;
 use std::sync::*;
+use testing_logger;
 
 fn new_peer(id: u64) -> Peer {
     Peer {
@@ -83,20 +84,22 @@ fn new_raw_node(
     heartbeat: usize,
     storage: MemStorage,
     peer_nodes: Vec<Peer>,
+    logger: &Logger,
 ) -> RawNode<MemStorage> {
     RawNode::new(
         &new_test_config(id, peers, election, heartbeat),
         storage,
         peer_nodes,
+        logger,
     ).unwrap()
 }
 
 // test_raw_node_step ensures that RawNode.Step ignore local message.
 #[test]
 fn test_raw_node_step() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "sending_snapshot_set_pending_snapshot"));
     for msg_t in MessageType::values() {
-        let mut raw_node = new_raw_node(1, vec![], 10, 1, new_storage(), vec![new_peer(1)]);
+        let mut raw_node = new_raw_node(1, vec![], 10, 1, new_storage(), vec![new_peer(1)], &l);
         let res = raw_node.step(new_message(0, 0, *msg_t, 0));
         // local msg should be ignored.
         if vec![
@@ -115,12 +118,12 @@ fn test_raw_node_step() {
 // forward to the new leader and 'send' method does not attach its term
 #[test]
 fn test_raw_node_read_index_to_old_leader() {
-    setup_for_test();
-    let r1 = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage());
-    let r2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage());
-    let r3 = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage());
+    let l = testing_logger().new(o!("test" => "raw_node_read_index_to_old_leader"));
+    let r1 = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
+    let r2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
+    let r3 = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
 
-    let mut nt = Network::new(vec![Some(r1), Some(r2), Some(r3)]);
+    let mut nt = Network::new(vec![Some(r1), Some(r2), Some(r3)], &l);
 
     // elect r1 as leader
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
@@ -177,9 +180,9 @@ fn test_raw_node_read_index_to_old_leader() {
 // RawNode.propose_conf_change send the given proposal and ConfChange to the underlying raft.
 #[test]
 fn test_raw_node_propose_and_conf_change() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_restart_from_snapshot"));
     let s = new_storage();
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)], &l);
     let rd = raw_node.ready();
     s.wl().append(&rd.entries).expect("");
     raw_node.advance(rd);
@@ -221,9 +224,9 @@ fn test_raw_node_propose_and_conf_change() {
 // not affect the later propose to add new node.
 #[test]
 fn test_raw_node_propose_add_duplicate_node() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_propose_add_duplicate_node"));
     let s = new_storage();
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)], &l);
     let rd = raw_node.ready();
     s.wl().append(&rd.entries).expect("");
     raw_node.advance(rd);
@@ -275,9 +278,9 @@ fn test_raw_node_propose_add_duplicate_node() {
 
 #[test]
 fn test_raw_node_propose_add_learner_node() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_propose_add_learner_node"));
     let s = new_storage();
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)], &l);
     let rd = raw_node.ready();
     s.wl().append(&rd.entries).expect("");
     raw_node.advance(rd);
@@ -316,7 +319,7 @@ fn test_raw_node_propose_add_learner_node() {
 // to the underlying raft. It also ensures that ReadState can be read out.
 #[test]
 fn test_raw_node_read_index() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_restart_from_snapshot"));
     let a = Arc::new(RwLock::new(Vec::new()));
     let b = Arc::clone(&a);
     let before_step_state = Box::new(move |m: &Message| {
@@ -330,7 +333,7 @@ fn test_raw_node_read_index() {
     }];
 
     let s = new_storage();
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)], &l);
     raw_node.raft.read_states = wrs.clone();
     // ensure the read_states can be read out
     assert!(raw_node.has_ready());
@@ -372,7 +375,7 @@ fn test_raw_node_read_index() {
 // proposals.
 #[test]
 fn test_raw_node_start() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_start"));
     let cc = conf_change(ConfChangeType::AddNode, 1);
     let ccdata = protobuf::Message::write_to_bytes(&cc).unwrap();
     let wants = vec![
@@ -403,9 +406,8 @@ fn test_raw_node_start() {
     ];
 
     let store = new_storage();
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, store.clone(), vec![new_peer(1)]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, store.clone(), vec![new_peer(1)], &l);
     let rd = raw_node.ready();
-    info!("rd {:?}", &rd);
     assert_eq!(rd, wants[0]);
     store.wl().append(&rd.entries).expect("");
     raw_node.advance(rd);
@@ -429,7 +431,7 @@ fn test_raw_node_start() {
 
 #[test]
 fn test_raw_node_restart() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_restart"));
     let entries = vec![empty_entry(1, 1), new_entry(1, 2, Some("foo"))];
     let st = hard_state(1, 1, 0);
 
@@ -438,7 +440,7 @@ fn test_raw_node_restart() {
     let store = new_storage();
     store.wl().set_hardstate(st);
     store.wl().append(&entries).expect("");
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, store, vec![]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, store, vec![], &l);
     let rd = raw_node.ready();
     assert_eq!(rd, want);
     raw_node.advance(rd);
@@ -447,7 +449,7 @@ fn test_raw_node_restart() {
 
 #[test]
 fn test_raw_node_restart_from_snapshot() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "raw_node_restart_from_snapshot"));
     let snap = new_snapshot(2, 1, vec![1, 2]);
     let entries = vec![new_entry(1, 3, Some("foo"))];
     let st = hard_state(1, 3, 0);
@@ -458,7 +460,7 @@ fn test_raw_node_restart_from_snapshot() {
     s.wl().set_hardstate(st);
     s.wl().apply_snapshot(snap).expect("");
     s.wl().append(&entries).expect("");
-    let mut raw_node = new_raw_node(1, vec![], 10, 1, s, vec![]);
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, s, vec![], &l);
     let rd = raw_node.ready();
     assert_eq!(rd, want);
     raw_node.advance(rd);
@@ -469,13 +471,13 @@ fn test_raw_node_restart_from_snapshot() {
 // when skip_bcast_commit is true.
 #[test]
 fn test_skip_bcast_commit() {
-    setup_for_test();
+    let l = testing_logger().new(o!("test" => "skip_bcast_commit"));
     let mut config = new_test_config(1, vec![1, 2, 3], 10, 1);
     config.skip_bcast_commit = true;
-    let r1 = new_test_raft_with_config(&config, new_storage());
-    let r2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage());
-    let r3 = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage());
-    let mut nt = Network::new(vec![Some(r1), Some(r2), Some(r3)]);
+    let r1 = new_test_raft_with_config(&config, new_storage(), &l);
+    let r2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
+    let r3 = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
+    let mut nt = Network::new(vec![Some(r1), Some(r2), Some(r3)], &l);
 
     // elect r1 as leader
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,11 +15,12 @@
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 
 #[macro_use]
-extern crate log;
-extern crate env_logger;
+extern crate slog;
 extern crate protobuf;
 extern crate raft;
 extern crate rand;
+
+pub use raft::testing_logger;
 
 /// Get the count of macro's arguments.
 ///
@@ -81,11 +82,6 @@ macro_rules! map {
             temp_map
         }
     };
-}
-
-/// Do any common test initialization. Eg set up logging, setup fail-rs.
-pub fn setup_for_test() {
-    let _ = env_logger::try_init();
 }
 
 mod cases;


### PR DESCRIPTION
Currently this PR completes the initial migration, I will be adding commits to trim out unnecessary information and organize the logging output better.

Preview at this moment:

![look](https://user-images.githubusercontent.com/130903/38904752-29786cdc-4261-11e8-956a-6719de986f81.jpg)

Please note this **breaks API** as the `Raft::new()` function accepts a new argument.

## Motivations

* We'd like to utilize the async capabilities of `slog` to possible increase speed.
* Structured logging can be very useful for offering crate consumers integration options.
* We'd like to add file rotation to `slog` eventually.

## Implementation notes

* `slog` offers many different logging modes. Including `term` and `html` etc, Raft (libraries in general) shouldn't have an opinion on this, it should just provide a log stream.
* `log`, the old logging crate, is still a viable fallback and we should allow users to fall back to using this.
* `slog` has an expanded style:
  ```rust
  warn!(
      logger,
      #"an optional tag, not reccomended for libraries (https://docs.rs/slog/2.2.3/slog/struct.Record.html#method.tag)",
      "some string describing the event: {detail}",
      // Note that all of these values are dumped into the structured output.
      detail = self.detail_value;
      "additional_structured_values" => "can go here",
  )
  ```
  