### PR TITLE
Have CI do a fmt as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   global:
     - RUST_BACKTRACE=1
-    - CLIPPY_VERSION=0.0.179
+    - CLIPPY_VERSION=0.0.192
     - RUSTFLAGS="-D warnings"
 cache: cargo
 
@@ -13,7 +13,7 @@ rust:
 matrix:
   include:
   - rust: stable
-  - rust: nightly-2018-01-12
+  - rust: nightly-2018-04-06
     install:
       - export PATH="$PATH:$HOME/.cargo/bin"
       - if [[ `cargo clippy -- --version` != $CLIPPY_VERSION* ]]; then cargo install -f clippy --version $CLIPPY_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,24 @@ env:
     - RUSTFLAGS="-D warnings"
 cache: cargo
 
-# `allow_failures` requires this, but we set it below.
 rust:
 
 matrix:
   include:
+  # This build uses stable and checks rustfmt (clippy is not on stable).
   - rust: stable
+    install:
+      - rustup component add rustfmt-preview
+    before_script:
+      - cargo fmt --all -- --write-mode diff
+  # This build uses the nightly used by TiKV and checks clippy.
   - rust: nightly-2018-04-06
     install:
       - export PATH="$PATH:$HOME/.cargo/bin"
       - if [[ `cargo clippy -- --version` != $CLIPPY_VERSION* ]]; then cargo install -f clippy --version $CLIPPY_VERSION; fi
+    before_script:
+      - cargo clippy
+
 
 script:
-  - if `which cargo-clippy &>/dev/null`; then cargo clippy; fi
   - cargo test --all -- --nocapture

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -13,10 +13,10 @@
 
 extern crate raft;
 
-use std::sync::mpsc::{self, RecvTimeoutError};
-use std::time::{Duration, Instant};
-use std::thread;
 use std::collections::HashMap;
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use raft::prelude::*;
 use raft::storage::MemStorage;
@@ -24,10 +24,14 @@ use raft::storage::MemStorage;
 type ProposeCallback = Box<Fn() + Send>;
 
 enum Msg {
-    Propose { id: u8, cb: ProposeCallback },
+    Propose {
+        id: u8,
+        cb: ProposeCallback,
+    },
     // Here we don't use Raft Message, so use dead_code to
     // avoid the compiler warning.
-    #[allow(dead_code)] Raft(Message),
+    #[allow(dead_code)]
+    Raft(Message),
 }
 
 // A simple example about how to use the Raft library in Rust.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cmp, io, result};
 use std::error;
+use std::{cmp, io, result};
 
 use protobuf::ProtobufError;
 
@@ -110,8 +110,8 @@ pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(test)]
 mod tests {
-    use std::io;
     use super::*;
+    use std::io;
 
     #[test]
     fn test_error_equal() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,27 +38,27 @@ extern crate quick_error;
 extern crate rand;
 
 pub mod eraftpb;
-mod raft_log;
-pub mod storage;
-mod raft;
-mod progress;
 mod errors;
 mod log_unstable;
-mod status;
+mod progress;
+mod raft;
+mod raft_log;
 pub mod raw_node;
 mod read_only;
+mod status;
+pub mod storage;
 pub mod util;
 
-pub use self::storage::{RaftState, Storage};
 pub use self::errors::{Error, Result, StorageError};
+pub use self::log_unstable::Unstable;
+pub use self::progress::{Inflights, Progress, ProgressSet, ProgressState};
 pub use self::raft::{quorum, vote_resp_msg_type, Config, Raft, SoftState, StateRole, INVALID_ID,
                      INVALID_INDEX};
 pub use self::raft_log::{RaftLog, NO_LIMIT};
 pub use self::raw_node::{is_empty_snap, Peer, RawNode, Ready, SnapshotStatus};
-pub use self::status::Status;
-pub use self::log_unstable::Unstable;
-pub use self::progress::{Inflights, Progress, ProgressSet, ProgressState};
 pub use self::read_only::{ReadOnlyOption, ReadState};
+pub use self::status::Status;
+pub use self::storage::{RaftState, Storage};
 
 pub mod prelude {
     //! A "prelude" for crates using the `raft` crate.

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -45,10 +45,10 @@ pub struct Unstable {
 impl Unstable {
     pub fn new(offset: u64, tag: String) -> Unstable {
         Unstable {
-            offset: offset,
+            offset,
             snapshot: None,
             entries: vec![],
-            tag: tag,
+            tag,
         }
     }
     // maybe_first_index returns the index of the first possible entry in entries

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -74,22 +74,25 @@ impl Unstable {
     // is any.
     pub fn maybe_term(&self, idx: u64) -> Option<u64> {
         if idx < self.offset {
-            if self.snapshot.is_none() {
-                return None;
+            match self.snapshot.as_ref() {
+                Some(snapshot) => {
+                    let meta = snapshot.get_metadata();
+                    if idx == meta.get_index() {
+                        Some(meta.get_term())
+                    } else {
+                        None
+                    }
+                },
+                None => None,
             }
-
-            let meta = self.snapshot.as_ref().unwrap().get_metadata();
-            if idx == meta.get_index() {
-                return Some(meta.get_term());
-            }
-            return None;
+        } else {
+            self.maybe_last_index().and_then(|last| {
+                if idx > last {
+                    return None;
+                }
+                Some(self.entries[(idx - self.offset) as usize].get_term())
+            })
         }
-        self.maybe_last_index().and_then(|last| {
-            if idx > last {
-                return None;
-            }
-            Some(self.entries[(idx - self.offset) as usize].get_term())
-        })
     }
 
     pub fn stable_to(&mut self, idx: u64, term: u64) {

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -74,16 +74,12 @@ impl Unstable {
     // is any.
     pub fn maybe_term(&self, idx: u64) -> Option<u64> {
         if idx < self.offset {
-            match self.snapshot.as_ref() {
-                Some(snapshot) => {
-                    let meta = snapshot.get_metadata();
-                    if idx == meta.get_index() {
-                        Some(meta.get_term())
-                    } else {
-                        None
-                    }
-                },
-                None => None,
+            let snapshot = self.snapshot.as_ref()?;
+            let meta = snapshot.get_metadata();
+            if idx == meta.get_index() {
+                Some(meta.get_term())
+            } else {
+                None
             }
         } else {
             self.maybe_last_index().and_then(|last| {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -25,10 +25,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::iter::Chain;
-use std::collections::hash_map::{HashMap, Iter, IterMut};
 use fxhash::FxHashMap;
+use std::cmp;
+use std::collections::hash_map::{HashMap, Iter, IterMut};
+use std::iter::Chain;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ProgressState {
@@ -382,7 +382,7 @@ mod test {
             inflight.add(i);
         }
 
-        let wantin = Inflights{
+        let wantin = Inflights {
             start: 0,
             count: 5,
             buffer: vec![0, 1, 2, 3, 4],
@@ -454,7 +454,7 @@ mod test {
         inflight.free_to(8);
 
         let wantin2 = Inflights {
-            start: 9, 
+            start: 9,
             count: 1,
             buffer: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         };
@@ -504,4 +504,3 @@ mod test {
         assert_eq!(inflight, wantin);
     }
 }
-

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -245,7 +245,7 @@ pub struct Raft<T: Storage> {
 
 fn new_progress(next_idx: u64, ins_size: usize) -> Progress {
     Progress {
-        next_idx: next_idx,
+        next_idx,
         ins: Inflights::new(ins_size),
         ..Default::default()
     }
@@ -299,7 +299,7 @@ impl<T: Storage> Raft<T> {
         let mut r = Raft {
             id: c.id,
             read_states: Default::default(),
-            raft_log: raft_log,
+            raft_log,
             max_inflight: c.max_inflight_msgs,
             max_msg_size: c.max_size_per_msg,
             prs: Some(ProgressSet::new(peers.len(), learners.len())),

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -27,16 +27,16 @@
 
 use std::cmp;
 
-use rand::{self, Rng};
 use eraftpb::{Entry, EntryType, HardState, Message, MessageType, Snapshot};
 use fxhash::FxHashMap;
 use protobuf::repeated::RepeatedField;
+use rand::{self, Rng};
 
-use super::storage::Storage;
-use super::progress::{Inflights, Progress, ProgressSet, ProgressState};
 use super::errors::{Error, Result, StorageError};
+use super::progress::{Inflights, Progress, ProgressSet, ProgressState};
 use super::raft_log::{self, RaftLog};
 use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};
+use super::storage::Storage;
 
 // CAMPAIGN_PRE_ELECTION represents the first phase of a normal election when
 // Config.pre_vote is true.

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -29,9 +29,9 @@ use std::cmp;
 
 use eraftpb::{Entry, Snapshot};
 
-use storage::Storage;
-use log_unstable::Unstable;
 use errors::{Error, Result, StorageError};
+use log_unstable::Unstable;
+use storage::Storage;
 use util;
 
 pub use util::NO_LIMIT;
@@ -430,11 +430,11 @@ impl<T: Storage> RaftLog<T> {
 mod test {
     use std::panic::{self, AssertUnwindSafe};
 
-    use raft_log::{self, RaftLog};
-    use storage::MemStorage;
     use eraftpb;
     use errors::{Error, StorageError};
     use protobuf;
+    use raft_log::{self, RaftLog};
+    use storage::MemStorage;
 
     fn new_raft_log(s: MemStorage) -> RaftLog<MemStorage> {
         RaftLog::new(s, String::from(""))

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -84,7 +84,7 @@ impl<T: Storage> RaftLog<T> {
             committed: first_index - 1,
             applied: first_index - 1,
             unstable: Unstable::new(last_index + 1, tag.clone()),
-            tag: tag,
+            tag,
         }
     }
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -27,14 +27,14 @@
 
 use std::mem;
 
-use protobuf::{self, RepeatedField};
 use eraftpb::{ConfChange, ConfChangeType, ConfState, Entry, EntryType, HardState, Message,
               MessageType, Snapshot};
+use protobuf::{self, RepeatedField};
 
-use super::errors::{Error, Result};
-use super::Storage;
-use super::raft::{Config, Raft, SoftState, INVALID_ID};
 use super::Status;
+use super::Storage;
+use super::errors::{Error, Result};
+use super::raft::{Config, Raft, SoftState, INVALID_ID};
 use super::read_only::ReadState;
 
 #[derive(Debug, Default)]
@@ -454,8 +454,8 @@ impl<T: Storage> RawNode<T> {
 
 #[cfg(test)]
 mod test {
-    use eraftpb::MessageType;
     use super::is_local_msg;
+    use eraftpb::MessageType;
 
     #[test]
     fn test_is_local_msg() {

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -78,7 +78,7 @@ pub struct ReadOnly {
 impl ReadOnly {
     pub fn new(option: ReadOnlyOption) -> ReadOnly {
         ReadOnly {
-            option: option,
+            option,
             pending_read_index: FxHashMap::default(),
             read_index_queue: VecDeque::new(),
         }
@@ -98,7 +98,7 @@ impl ReadOnly {
         };
         let status = ReadIndexStatus {
             req: m,
-            index: index,
+            index,
             acks: FxHashSet::default(),
         };
         self.pending_read_index.insert(ctx.clone(), status);

--- a/src/status.rs
+++ b/src/status.rs
@@ -28,9 +28,9 @@
 use eraftpb::HardState;
 use fxhash::FxHashMap;
 
+use progress::Progress;
 use raft::{Raft, SoftState, StateRole};
 use storage::Storage;
-use progress::Progress;
 
 #[derive(Default)]
 pub struct Status {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -303,8 +303,8 @@ impl Storage for MemStorage {
 
 #[cfg(test)]
 mod test {
-    use protobuf;
     use eraftpb::{ConfState, Entry, Snapshot};
+    use protobuf;
 
     use errors::{Error as RaftError, StorageError};
     use storage::{MemStorage, Storage};

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 mod test_raft;
-mod test_raft_snap;
-mod test_raft_paper;
 mod test_raft_flow_control;
+mod test_raft_paper;
+mod test_raft_snap;
 mod test_raw_node;

--- a/tests/cases/test_raft.rs
+++ b/tests/cases/test_raft.rs
@@ -25,10 +25,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::ops::DerefMut;
-use std::cmp;
 use std::panic::{self, AssertUnwindSafe};
 
 use protobuf::{self, RepeatedField};
@@ -36,8 +36,8 @@ use raft::eraftpb::{ConfChange, ConfChangeType, ConfState, Entry, EntryType, Har
                     MessageType, Snapshot};
 use rand;
 
-use raft::*;
 use raft::storage::MemStorage;
+use raft::*;
 
 pub fn ltoa(raft_log: &RaftLog<MemStorage>) -> String {
     let mut s = format!("committed: {}\n", raft_log.committed);
@@ -897,34 +897,22 @@ fn test_vote_from_any_state_for_type(vt: MessageType) {
                 StateRole::Follower
             );
             assert_eq!(
-                r.term,
-                new_term,
+                r.term, new_term,
                 "{:?},{:?}, term {}, want {}",
-                vt,
-                state,
-                r.term,
-                new_term
+                vt, state, r.term, new_term
             );
             assert_eq!(r.vote, 2, "{:?},{:?}, vote {}, want 2", vt, state, r.vote);
         } else {
             // In a pre-vote, nothing changes.
             assert_eq!(
-                r.state,
-                state,
+                r.state, state,
                 "{:?},{:?}, state {:?}, want {:?}",
-                vt,
-                state,
-                r.state,
-                state
+                vt, state, r.state, state
             );
             assert_eq!(
-                r.term,
-                orig_term,
+                r.term, orig_term,
                 "{:?},{:?}, term {}, want {}",
-                vt,
-                state,
-                r.term,
-                orig_term
+                vt, state, r.term, orig_term
             );
             // If state == Follower or PreCandidate, r hasn't voted yet.
             // In Candidate or Leader, it's voted for itself.
@@ -2030,11 +2018,9 @@ fn test_candidate_reset_term(message_type: MessageType) {
 
     // follower c term is reset with leader's
     assert_eq!(
-        nt.peers[&3].term,
-        nt.peers[&1].term,
+        nt.peers[&3].term, nt.peers[&1].term,
         "follower term expected same term as leader's {}, got {}",
-        nt.peers[&1].term,
-        nt.peers[&3].term,
+        nt.peers[&1].term, nt.peers[&3].term,
     )
 }
 

--- a/tests/cases/test_raft_paper.rs
+++ b/tests/cases/test_raft_paper.rs
@@ -26,10 +26,10 @@
 // limitations under the License.
 
 use super::test_raft::*;
-use raft::eraftpb::*;
-use raft::*;
-use raft::storage::MemStorage;
 use protobuf::RepeatedField;
+use raft::eraftpb::*;
+use raft::storage::MemStorage;
+use raft::*;
 
 pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {
     let mut hs = HardState::new();

--- a/tests/cases/test_raw_node.rs
+++ b/tests/cases/test_raw_node.rs
@@ -25,14 +25,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
-use std::rc::Rc;
-use raft::eraftpb::*;
-use protobuf::{self, ProtobufEnum};
-use raft::*;
-use raft::storage::MemStorage;
 use super::test_raft::*;
 use super::test_raft_paper::*;
+use protobuf::{self, ProtobufEnum};
+use raft::eraftpb::*;
+use raft::storage::MemStorage;
+use raft::*;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 fn new_peer(id: u64) -> Peer {
     Peer {


### PR DESCRIPTION
Currently we're not using `rustfmt` via CI for Raft, and we should be! This configures it.