### PR TITLE
fix compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "database-implementations"]
 
 [dependencies]
 log = "0.4.1"
-protobuf = "1.6"
+protobuf = "2.0"
 quick-error = "1.2.1"
 rand = "0.4"
 fxhash = "0.2.1"


### PR DESCRIPTION
According to stepancheg/rust-protobuf#289, we need to use 2.0 now.