### PR TITLE
raft: fix quorum math for abnormal sizes

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -317,7 +317,10 @@ pub fn vote_resp_msg_type(t: MessageType) -> MessageType {
 
 // Calculate the quorum of a Raft cluster with the specified total nodes.
 pub fn quorum(total: usize) -> usize {
-    total / 2 + 1
+    match total {
+        0...2 => total,
+        _ => total / 2 + 1,
+    }
 }
 
 impl<T: Storage> Raft<T> {

--- a/tests/cases/test_raft.rs
+++ b/tests/cases/test_raft.rs
@@ -4118,3 +4118,14 @@ fn test_election_tick_range() {
         assert_eq!(randomized_timeout, cfg.election_tick);
     }
 }
+
+#[test]
+fn test_quorum_math() {
+    let arbitrary_max_test = 15;
+    assert!(quorum(0) == 0);
+    for n in 1..arbitrary_max_test {
+        let q = quorum(n);
+        assert!(q > 0, "q={} and n={}", q, n);
+        assert!(q <= n, "q={} and n={}", q, n);
+    }
+}


### PR DESCRIPTION
This updates quorum math for cluster of abnormal size (< 3 members).
It also adds a test to ensure that quorum number is bound between 1 and
the size of the cluster.