### PR TITLE
move msg broadcast to ready

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -657,6 +657,11 @@ impl<T: Storage> Raft<T> {
     // bcast_append sends RPC, with entries to all peers that are not up-to-date
     // according to the progress recorded in r.prs().
     pub fn bcast_append(&mut self) {
+        if !self.need_bcast {
+            return;
+        }
+        self.need_bcast = false;
+
         let self_id = self.id;
         let mut prs = self.take_prs();
         prs.iter_mut()

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -130,6 +130,9 @@ impl Ready {
             entries: raft.raft_log.unstable_entries().unwrap_or(&[]).to_vec(),
             ..Default::default()
         };
+        if raft.need_bcast {
+            raft.bcast_append();
+        }
         if !raft.msgs.is_empty() {
             mem::swap(&mut raft.msgs, &mut rd.messages);
         }
@@ -328,7 +331,7 @@ impl<T: Storage> RawNode<T> {
 
     pub fn has_ready_since(&self, applied_idx: Option<u64>) -> bool {
         let raft = &self.raft;
-        if !raft.msgs.is_empty() || raft.raft_log.unstable_entries().is_some() {
+        if raft.need_bcast || !raft.msgs.is_empty() || raft.raft_log.unstable_entries().is_some() {
             return true;
         }
         if !raft.read_states.is_empty() {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -130,9 +130,8 @@ impl Ready {
             entries: raft.raft_log.unstable_entries().unwrap_or(&[]).to_vec(),
             ..Default::default()
         };
-        if raft.need_bcast {
-            raft.bcast_append();
-        }
+        // perform bcast_append to trigger actual message broadcast
+        raft.bcast_append();
         if !raft.msgs.is_empty() {
             mem::swap(&mut raft.msgs, &mut rd.messages);
         }

--- a/tests/cases/test_raft.rs
+++ b/tests/cases/test_raft.rs
@@ -112,6 +112,7 @@ pub fn new_test_raft_with_config(config: &Config, storage: MemStorage) -> Interf
 }
 
 fn read_messages<T: Storage>(raft: &mut Raft<T>) -> Vec<Message> {
+    raft.bcast_append();
     raft.msgs.drain(..).collect()
 }
 
@@ -191,7 +192,11 @@ impl Interface {
 
     pub fn read_messages(&mut self) -> Vec<Message> {
         match self.raft {
-            Some(_) => self.msgs.drain(..).collect(),
+            Some(_) => {
+                // perform bcast_append to trigger actual message broadcast
+                self.bcast_append();
+                self.msgs.drain(..).collect()
+            },
             None => vec![],
         }
     }
@@ -2673,6 +2678,8 @@ fn test_leader_append_response() {
         m.set_reject_hint(index);
         sm.step(m).expect("");
 
+        // perform read_messages to trigger actual message broadcast
+        let mut msgs = sm.read_messages();
         if sm.prs().voters()[&2].matched != wmatch {
             panic!(
                 "#{}: match = {}, want {}",
@@ -2689,8 +2696,6 @@ fn test_leader_append_response() {
                 wnext
             );
         }
-
-        let mut msgs = sm.read_messages();
         if msgs.len() != wmsg_num {
             panic!("#{} msg_num = {}, want {}", i, msgs.len(), wmsg_num);
         }
@@ -2846,6 +2851,8 @@ fn test_leader_increase_next() {
         sm.step(new_message(1, 1, MessageType::MsgPropose, 1))
             .expect("");
 
+        // perform read_messages to trigger actual message broadcast
+        sm.read_messages();
         if sm.prs().voters()[&2].next_idx != wnext {
             panic!(
                 "#{}: next = {}, want {}",

--- a/tests/cases/test_raft_paper.rs
+++ b/tests/cases/test_raft_paper.rs
@@ -41,7 +41,7 @@ pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {
 
 fn commit_noop_entry(r: &mut Interface, s: &MemStorage) {
     assert_eq!(r.state, StateRole::Leader);
-    r.bcast_append();
+    r.bcast();
     // simulate the response of MsgAppend
     let msgs = r.read_messages();
     for m in msgs {


### PR DESCRIPTION
there are few place to call "bcast_append" in raft, but messages won't actually be broadcast until we handle raft ready, so we don't have to actually generate message until we handle raft ready, we just mark a flag "need_bcast" as true.

realated issue:
https://github.com/pingcap/tikv/issues/2583
https://github.com/pingcap/raft-rs/issues/18