### PR TITLE
rustfmt: Use default fmt configuration

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-use_try_shorthand = true


### PR DESCRIPTION
Fixes https://github.com/pingcap/raft-rs/issues/62.