### PR TITLE
travis: Use rustup provided clippy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 env:
   global:
     - RUST_BACKTRACE=1
-    - CLIPPY_VERSION=0.0.192
     - RUSTFLAGS="-D warnings"
 cache: cargo
 
@@ -17,11 +16,9 @@ matrix:
       - rustup component add rustfmt-preview
     before_script:
       - cargo fmt --all -- --write-mode diff
-  # This build uses the nightly used by TiKV and checks clippy.
-  - rust: nightly-2018-04-06
+  - rust: nightly
     install:
-      - export PATH="$PATH:$HOME/.cargo/bin"
-      - if [[ `cargo clippy -- --version` != $CLIPPY_VERSION* ]]; then cargo install -f clippy --version $CLIPPY_VERSION; fi
+      - rustup component add clippy-preview --toolchain nightly
     before_script:
       - cargo clippy
 


### PR DESCRIPTION
Also see: https://internals.rust-lang.org/t/clippy-is-available-as-a-rustup-component/7967

Move the clippy we use from being installed by `cargo` to being installed by `rustup`. If you find strange problems with clippy after they are merged you will need to do: `cargo uninstall clippy && cargo uninstall clippy-lints && rustup self update`

This is because the old versions of rustup don't know that clippy is managed, so they give errors like `subcommand clippy does not exist`.

### Reasons for doing this:

Currently the clippy version must be managed separate from the Rust nightly. Using Rustup will allow each of our projects to depend on their own clippy versions and help avoid some toolchain related problems.

### The PRs:

* https://github.com/pingcap/raft-rs/pull/95
* https://github.com/pingcap/rust-prometheus/pull/186
* https://github.com/pingcap/grpc-rs/pull/208
* https://github.com/pingcap/fail-rs/pull/13
* https://github.com/pingcap/tikv/pull/3335