### PR TITLE
Use a single set of Progresses for ProgressSet.

### DIFF
--- a/benches/suites/progress_set.rs
+++ b/benches/suites/progress_set.rs
@@ -4,6 +4,7 @@ use DEFAULT_RAFT_SETS;
 
 pub fn bench_progress_set(c: &mut Criterion) {
     bench_progress_set_new(c);
+    bench_progress_set_with_capacity(c);
     bench_progress_set_insert_voter(c);
     bench_progress_set_insert_learner(c);
     bench_progress_set_promote_learner(c);
@@ -14,7 +15,7 @@ pub fn bench_progress_set(c: &mut Criterion) {
 }
 
 fn quick_progress_set(voters: usize, learners: usize) -> ProgressSet {
-    let mut set = ProgressSet::new(voters, learners);
+    let mut set = ProgressSet::with_capacity(voters, learners);
     (0..voters).for_each(|id| {
         set.insert_voter(id as u64, Default::default()).ok();
     });
@@ -25,16 +26,25 @@ fn quick_progress_set(voters: usize, learners: usize) -> ProgressSet {
 }
 
 pub fn bench_progress_set_new(c: &mut Criterion) {
+    let bench = |b: &mut Bencher| {
+        // No setup.
+        b.iter(|| ProgressSet::new());
+    };
+
+    c.bench_function(&format!("ProgressSet::new"), bench);
+}
+
+pub fn bench_progress_set_with_capacity(c: &mut Criterion) {
     let bench = |voters, learners| {
         move |b: &mut Bencher| {
             // No setup.
-            b.iter(|| ProgressSet::new(voters, learners));
+            b.iter(|| ProgressSet::with_capacity(voters, learners));
         }
     };
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::new ({}, {})", voters, learners),
+            &format!("ProgressSet::with_capacity ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });

--- a/benches/suites/progress_set.rs
+++ b/benches/suites/progress_set.rs
@@ -31,7 +31,7 @@ pub fn bench_progress_set_new(c: &mut Criterion) {
         b.iter(|| ProgressSet::new());
     };
 
-    c.bench_function(&format!("ProgressSet::new"), bench);
+    c.bench_function("ProgressSet::new", bench);
 }
 
 pub fn bench_progress_set_with_capacity(c: &mut Criterion) {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -155,26 +155,46 @@ impl ProgressSet {
     /// Adds a voter node
     pub fn insert_voter(&mut self, id: u64, mut pr: Progress) -> Result<(), Error> {
         if self.learner_ids().contains(&id) {
-            Err(Error::Exists(id, "learners"))?;
+            return Err(Error::Exists(id, "learners"));
         } else if self.voter_ids().contains(&id) {
-            Err(Error::Exists(id, "voters"))?;
+            return Err(Error::Exists(id, "voters"));
         }
         pr.is_learner = false;
         self.configuration.voters.insert(id);
         self.progress.insert(id, pr);
+        debug_assert!(
+            self.configuration
+                .voters
+                .union(&self.configuration.learners)
+                .all(|v| self.progress.contains_key(v))
+        );
+        assert_eq!(
+            self.configuration.voters.len() + self.configuration.learners.len(),
+            self.progress.len()
+        );
         Ok(())
     }
 
     /// Adds a learner to the cluster
     pub fn insert_learner(&mut self, id: u64, mut pr: Progress) -> Result<(), Error> {
         if self.learner_ids().contains(&id) {
-            Err(Error::Exists(id, "learners"))?;
+            return Err(Error::Exists(id, "learners"));
         } else if self.voter_ids().contains(&id) {
-            Err(Error::Exists(id, "voters"))?;
+            return Err(Error::Exists(id, "voters"));
         }
         pr.is_learner = true;
         self.configuration.learners.insert(id);
         self.progress.insert(id, pr);
+        debug_assert!(
+            self.configuration
+                .voters
+                .union(&self.configuration.learners)
+                .all(|v| self.progress.contains_key(v))
+        );
+        assert_eq!(
+            self.configuration.voters.len() + self.configuration.learners.len(),
+            self.progress.len()
+        );
         Ok(())
     }
 
@@ -182,19 +202,31 @@ impl ProgressSet {
     pub fn remove(&mut self, id: u64) -> Option<Progress> {
         self.configuration.voters.remove(&id);
         self.configuration.learners.remove(&id);
-        self.progress.remove(&id)
+        let removed = self.progress.remove(&id);
+        debug_assert!(
+            self.configuration
+                .voters
+                .union(&self.configuration.learners)
+                .all(|v| self.progress.contains_key(v))
+        );
+        assert_eq!(
+            self.configuration.voters.len() + self.configuration.learners.len(),
+            self.progress.len()
+        );
+        removed
     }
 
     /// Promote a learner to a peer.
     pub fn promote_learner(&mut self, id: u64) -> Result<(), Error> {
         match self.progress.get_mut(&id) {
-            Some(ref progress) if !progress.is_learner => Err(Error::Exists(id, "voters"))?,
-            Some(progress) => {
+            Some(progress) => if !progress.is_learner {
+                Err(Error::Exists(id, "voters"))
+            } else {
                 progress.is_learner = false;
                 self.configuration.voters.insert(id);
                 self.configuration.learners.remove(&id);
                 Ok(())
-            }
+            },
             None => Err(Error::NotExists(id, "learners")),
         }
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -159,9 +159,8 @@ impl ProgressSet {
             // Determine the correct error to return.
             if self.learner_ids().contains(&id) {
                 return Err(Error::Exists(id, "learners"));
-            } else if self.voter_ids().contains(&id) {
-                return Err(Error::Exists(id, "voters"));
             }
+            return Err(Error::Exists(id, "voters"));
         }
         pr.is_learner = false;
         self.configuration.voters.insert(id);
@@ -177,9 +176,8 @@ impl ProgressSet {
             // Determine the correct error to return.
             if self.learner_ids().contains(&id) {
                 return Err(Error::Exists(id, "learners"));
-            } else if self.voter_ids().contains(&id) {
-                return Err(Error::Exists(id, "voters"));
             }
+            return Err(Error::Exists(id, "voters"));
         }
         pr.is_learner = true;
         self.configuration.learners.insert(id);

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -26,9 +26,9 @@
 // limitations under the License.
 
 use errors::Error;
-use fxhash::FxHashMap;
+use fxhash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::cmp;
-use std::collections::hash_map::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// The state of the progress.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -47,118 +47,155 @@ impl Default for ProgressState {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct Configuration {
+    voters: FxHashSet<u64>,
+    learners: FxHashSet<u64>,
+}
+
 /// `ProgressSet` contains several `Progress`es,
 /// which could be `Leader`, `Follower` and `Learner`.
 #[derive(Default, Clone)]
 pub struct ProgressSet {
-    voters: FxHashMap<u64, Progress>,
-    learners: FxHashMap<u64, Progress>,
+    progress: FxHashMap<u64, Progress>,
+    configuration: Configuration,
 }
 
 impl ProgressSet {
     /// Creates a new ProgressSet.
-    pub fn new(voter_size: usize, learner_size: usize) -> Self {
+    pub fn new() -> Self {
         ProgressSet {
-            voters: HashMap::with_capacity_and_hasher(voter_size, Default::default()),
-            learners: HashMap::with_capacity_and_hasher(learner_size, Default::default()),
+            progress: Default::default(),
+            configuration: Default::default(),
+        }
+    }
+
+    /// Create a progress sete with the specified sizes already reserved.
+    pub fn with_capacity(voters: usize, learners: usize) -> Self {
+        ProgressSet {
+            progress: HashMap::with_capacity_and_hasher(
+                voters + learners,
+                FxBuildHasher::default(),
+            ),
+            configuration: Configuration {
+                voters: HashSet::with_capacity_and_hasher(voters, FxBuildHasher::default()),
+                learners: HashSet::with_capacity_and_hasher(learners, FxBuildHasher::default()),
+            },
         }
     }
 
     /// Returns the status of voters.
-    pub fn voters(&self) -> &FxHashMap<u64, Progress> {
-        &self.voters
+    #[inline]
+    pub fn voters(&self) -> impl Iterator<Item = (&u64, &Progress)> {
+        let set = self.voter_ids();
+        self.progress.iter().filter(move |(&k, _)| set.contains(&k))
     }
 
     /// Returns the status of learners.
-    pub fn learners(&self) -> &FxHashMap<u64, Progress> {
-        &self.learners
+    #[inline]
+    pub fn learners(&self) -> impl Iterator<Item = (&u64, &Progress)> {
+        let set = self.learner_ids();
+        self.progress.iter().filter(move |(&k, _)| set.contains(&k))
     }
 
-    /// Returns the ids of all known nodes.
-    pub fn nodes(&self) -> Vec<u64> {
-        let mut nodes = Vec::with_capacity(self.voters.len());
-        nodes.extend(self.voters.keys());
-        nodes.sort();
-        nodes
+    /// Returns the mutable status of voters.
+    #[inline]
+    pub fn voters_mut(&mut self) -> impl Iterator<Item = (&u64, &mut Progress)> {
+        let ids = &self.configuration.voters;
+        self.progress
+            .iter_mut()
+            .filter(move |(k, _)| ids.contains(k))
+    }
+
+    /// Returns the mutable status of learners.
+    #[inline]
+    pub fn learners_mut(&mut self) -> impl Iterator<Item = (&u64, &mut Progress)> {
+        let ids = &self.configuration.learners;
+        self.progress
+            .iter_mut()
+            .filter(move |(k, _)| ids.contains(k))
+    }
+
+    /// Returns the ids of all known voters.
+    #[inline]
+    pub fn voter_ids(&self) -> &FxHashSet<u64> {
+        &self.configuration.voters
     }
 
     /// Returns the ids of all known learners.
-    pub fn learner_nodes(&self) -> Vec<u64> {
-        let mut ids = Vec::with_capacity(self.learners.len());
-        ids.extend(self.learners.keys());
-        ids.sort();
-        ids
+    #[inline]
+    pub fn learner_ids(&self) -> &FxHashSet<u64> {
+        &self.configuration.learners
     }
 
     /// Grabs a reference to the progress of a node.
+    #[inline]
     pub fn get(&self, id: u64) -> Option<&Progress> {
-        self.voters.get(&id).or_else(|| self.learners.get(&id))
+        self.progress.get(&id)
     }
 
     /// Grabs a mutable reference to the progress of a node.
+    #[inline]
     pub fn get_mut(&mut self, id: u64) -> Option<&mut Progress> {
-        let progress = self.voters.get_mut(&id);
-        if progress.is_none() {
-            return self.learners.get_mut(&id);
-        }
-        progress
+        self.progress.get_mut(&id)
     }
 
     /// Returns an iterator across all the nodes and their progress.
-    pub fn iter(&self) -> impl Iterator<Item = (&u64, &Progress)> {
-        self.voters.iter().chain(&self.learners)
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&u64, &Progress)> {
+        self.progress.iter()
     }
 
     /// Returns a mutable iterator across all the nodes and their progress.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&u64, &mut Progress)> {
-        self.voters.iter_mut().chain(&mut self.learners)
+    #[inline]
+    pub fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (&u64, &mut Progress)> {
+        self.progress.iter_mut()
     }
 
     /// Adds a voter node
-    pub fn insert_voter(&mut self, id: u64, pr: Progress) -> Result<(), Error> {
-        if self.voters.contains_key(&id) {
-            Err(Error::Exists(id, "voters"))?
-        }
-        if self.learners.contains_key(&id) {
+    pub fn insert_voter(&mut self, id: u64, mut pr: Progress) -> Result<(), Error> {
+        if self.learner_ids().contains(&id) {
             Err(Error::Exists(id, "learners"))?;
+        } else if self.voter_ids().contains(&id) {
+            Err(Error::Exists(id, "voters"))?;
         }
-        self.voters.insert(id, pr);
+        pr.is_learner = false;
+        self.configuration.voters.insert(id);
+        self.progress.insert(id, pr);
         Ok(())
     }
 
     /// Adds a learner to the cluster
-    pub fn insert_learner(&mut self, id: u64, pr: Progress) -> Result<(), Error> {
-        if self.voters.contains_key(&id) {
-            Err(Error::Exists(id, "voters"))?
+    pub fn insert_learner(&mut self, id: u64, mut pr: Progress) -> Result<(), Error> {
+        if self.learner_ids().contains(&id) {
+            Err(Error::Exists(id, "learners"))?;
+        } else if self.voter_ids().contains(&id) {
+            Err(Error::Exists(id, "voters"))?;
         }
-        if self.learners.contains_key(&id) {
-            Err(Error::Exists(id, "learners"))?
-        }
-        self.learners.insert(id, pr);
+        pr.is_learner = true;
+        self.configuration.learners.insert(id);
+        self.progress.insert(id, pr);
         Ok(())
     }
 
     /// Removes the peer from the set of voters or learners.
     pub fn remove(&mut self, id: u64) -> Option<Progress> {
-        match self.voters.remove(&id) {
-            None => self.learners.remove(&id),
-            some => some,
-        }
+        self.configuration.voters.remove(&id);
+        self.configuration.learners.remove(&id);
+        self.progress.remove(&id)
     }
 
     /// Promote a learner to a peer.
     pub fn promote_learner(&mut self, id: u64) -> Result<(), Error> {
-        if self.voters.contains_key(&id) {
-            Err(Error::Exists(id, "voters"))?;
-        }
-        // We don't want to remove it unless it's there.
-        if self.learners.contains_key(&id) {
-            let mut learner = self.learners.remove(&id).unwrap(); // We just checked!
-            learner.is_learner = false;
-            self.voters.insert(id, learner);
-            Ok(())
-        } else {
-            Err(Error::NotExists(id, "learners"))
+        match self.progress.get_mut(&id) {
+            Some(ref progress) if !progress.is_learner => Err(Error::Exists(id, "voters"))?,
+            Some(progress) => {
+                progress.is_learner = false;
+                self.configuration.voters.insert(id);
+                self.configuration.learners.remove(&id);
+                Ok(())
+            }
+            None => Err(Error::NotExists(id, "learners")),
         }
     }
 }
@@ -209,6 +246,16 @@ pub struct Progress {
 }
 
 impl Progress {
+    /// Creates a new progress with the given settings.
+    pub fn new(next_idx: u64, ins_size: usize, is_learner: bool) -> Self {
+        Progress {
+            next_idx,
+            ins: Inflights::new(ins_size),
+            is_learner,
+            ..Default::default()
+        }
+    }
+
     fn reset_state(&mut self, state: ProgressState) {
         self.paused = false;
         self.pending_snapshot = 0;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1761,7 +1761,7 @@ impl<T: Storage> Raft<T> {
         }
 
         // Both of learners and voters are empty means the peer is created by ConfChange.
-        if (self.prs().iter().len() != 0) && !self.is_learner {
+        if self.prs().iter().len() != 0 && !self.is_learner {
             for &id in meta.get_conf_state().get_learners() {
                 if id == self.id {
                     error!(

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -33,7 +33,7 @@ use protobuf::RepeatedField;
 use rand::{self, Rng};
 
 use super::errors::{Error, Result, StorageError};
-use super::progress::{Inflights, Progress, ProgressSet, ProgressState};
+use super::progress::{Progress, ProgressSet, ProgressState};
 use super::raft_log::{self, RaftLog};
 use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};
 use super::storage::Storage;
@@ -184,14 +184,6 @@ trait AssertSend: Send {}
 
 impl<T: Storage + Send> AssertSend for Raft<T> {}
 
-fn new_progress(next_idx: u64, ins_size: usize) -> Progress {
-    Progress {
-        next_idx,
-        ins: Inflights::new(ins_size),
-        ..Default::default()
-    }
-}
-
 fn new_message(to: u64, field_type: MessageType, from: Option<u64>) -> Message {
     let mut m = Message::new();
     m.set_to(to);
@@ -244,7 +236,7 @@ impl<T: Storage> Raft<T> {
             raft_log,
             max_inflight: c.max_inflight_msgs,
             max_msg_size: c.max_size_per_msg,
-            prs: Some(ProgressSet::new(peers.len(), learners.len())),
+            prs: Some(ProgressSet::new()),
             state: StateRole::Follower,
             is_learner: false,
             check_quorum: c.check_quorum,
@@ -268,14 +260,13 @@ impl<T: Storage> Raft<T> {
             tag: c.tag.to_owned(),
         };
         for p in peers {
-            let pr = new_progress(1, r.max_inflight);
+            let pr = Progress::new(r.raft_log.last_index(), r.max_inflight, false);
             if let Err(e) = r.mut_prs().insert_voter(*p, pr) {
                 panic!("{}", e);
             }
         }
         for p in learners {
-            let mut pr = new_progress(1, r.max_inflight);
-            pr.is_learner = true;
+            let pr = Progress::new(r.raft_log.last_index(), r.max_inflight, true);
             if let Err(e) = r.mut_prs().insert_learner(*p, pr) {
                 panic!("{}", e);
             };
@@ -296,7 +287,7 @@ impl<T: Storage> Raft<T> {
             "{} newRaft [peers: {:?}, term: {:?}, commit: {}, applied: {}, last_index: {}, \
              last_term: {}]",
             r.tag,
-            r.prs().nodes(),
+            r.prs().voters().collect::<Vec<_>>(),
             r.term,
             r.raft_log.committed,
             r.raft_log.get_applied(),
@@ -359,7 +350,7 @@ impl<T: Storage> Raft<T> {
     }
 
     fn quorum(&self) -> usize {
-        quorum(self.prs().voters().len())
+        quorum(self.prs().voter_ids().len())
     }
 
     /// For testing leader lease
@@ -587,13 +578,14 @@ impl<T: Storage> Raft<T> {
     pub fn maybe_commit(&mut self) -> bool {
         let mut mis_arr = [0; 5];
         let mut mis_vec;
-        let mis = if self.prs().voters().len() <= 5 {
-            &mut mis_arr[..self.prs().voters().len()]
+        let voters = self.prs().voter_ids().len();
+        let mis = if voters <= 5 {
+            &mut mis_arr[..voters]
         } else {
-            mis_vec = vec![0; self.prs().voters().len()];
+            mis_vec = vec![0; voters];
             mis_vec.as_mut_slice()
         };
-        for (i, pr) in self.prs().voters().values().enumerate() {
+        for (i, pr) in self.prs().voters().map(|(_, v)| v).enumerate() {
             mis[i] = pr.matched;
         }
         // reverse sort
@@ -623,9 +615,7 @@ impl<T: Storage> Raft<T> {
         let (last_index, max_inflight) = (self.raft_log.last_index(), self.max_inflight);
         let self_id = self.id;
         for (&id, pr) in self.mut_prs().iter_mut() {
-            let is_learner = pr.is_learner;
-            *pr = new_progress(last_index + 1, max_inflight);
-            pr.is_learner = is_learner;
+            *pr = Progress::new(last_index + 1, max_inflight, pr.is_learner);
             if id == self_id {
                 pr.matched = last_index;
             }
@@ -819,7 +809,7 @@ impl<T: Storage> Raft<T> {
         // Only send vote request to voters.
         let prs = self.take_prs();
         prs.voters()
-            .keys()
+            .map(|(k, _)| k)
             .filter(|&id| *id != self_id)
             .for_each(|&id| {
                 info!(
@@ -1327,7 +1317,7 @@ impl<T: Storage> Raft<T> {
                 self.handle_append_response(m, &mut prs, old_paused, send_append, maybe_commit);
             }
             MessageType::MsgHeartbeatResponse => {
-                let quorum = quorum(prs.voters().len());
+                let quorum = quorum(prs.voter_ids().len());
                 self.handle_heartbeat_response(m, &mut prs, quorum, send_append, more_to_send);
             }
             MessageType::MsgSnapStatus => {
@@ -1381,7 +1371,7 @@ impl<T: Storage> Raft<T> {
                 if m.get_entries().is_empty() {
                     panic!("{} stepped empty MsgProp", self.tag);
                 }
-                if !self.prs().voters().contains_key(&self.id) {
+                if !self.prs().voter_ids().contains(&self.id) {
                     // If we are not currently a member of the range (i.e. this node
                     // was removed from the configuration while serving as leader),
                     // drop any new proposals.
@@ -1770,9 +1760,7 @@ impl<T: Storage> Raft<T> {
         }
 
         // Both of learners and voters are empty means the peer is created by ConfChange.
-        if (!self.prs().voters().is_empty() || !self.prs().learners().is_empty())
-            && !self.is_learner
-        {
+        if (self.prs().iter().len() != 0) && !self.is_learner {
             for &id in meta.get_conf_state().get_learners() {
                 if id == self.id {
                     error!(
@@ -1799,7 +1787,7 @@ impl<T: Storage> Raft<T> {
 
         let nodes = meta.get_conf_state().get_nodes();
         let learners = meta.get_conf_state().get_learners();
-        self.prs = Some(ProgressSet::new(nodes.len(), learners.len()));
+        self.prs = Some(ProgressSet::with_capacity(nodes.len(), learners.len()));
 
         for &(is_learner, nodes) in &[(false, nodes), (true, learners)] {
             for &n in nodes {
@@ -1851,35 +1839,34 @@ impl<T: Storage> Raft<T> {
     /// Indicates whether state machine can be promoted to leader,
     /// which is true when its own id is in progress list.
     pub fn promotable(&self) -> bool {
-        self.prs().voters().contains_key(&self.id)
+        self.prs().voter_ids().contains(&self.id)
     }
 
-    fn add_voter_or_learner(&mut self, id: u64, is_learner: bool) {
-        if self.prs().voters().contains_key(&id) {
-            if is_learner {
-                info!(
-                    "{} ignored add learner: do not support changing {} from voter to learner",
-                    self.tag, id
-                );
-            }
-            // Ignore redundant add voter.
-            return;
-        } else if self.prs().learners().contains_key(&id) {
-            if is_learner {
-                // Ignore redundant add learner.
+    fn add_voter_or_learner(&mut self, id: u64, learner: bool) {
+        debug!(
+            "Adding node (learner: {}) with ID {} to peers.",
+            learner, id
+        );
+        let progress = Progress::new(self.raft_log.last_index(), self.max_inflight, learner);
+        // Ignore redundant inserts.
+        if let Some(progress) = self.prs().get(id) {
+            if progress.is_learner == learner {
                 return;
             }
-            if let Err(e) = self.mut_prs().promote_learner(id) {
-                panic!("{}", e)
-            }
-            if id == self.id {
-                self.is_learner = false;
-            }
+        };
+
+        let result = if learner {
+            self.mut_prs().insert_learner(id, progress)
+        } else if self.prs().learner_ids().contains(&id) {
+            self.mut_prs().promote_learner(id)
         } else {
-            // New progress.
-            let last_index = self.raft_log.last_index();
-            self.set_progress(id, 0, last_index + 1, is_learner);
+            self.mut_prs().insert_voter(id, progress)
+        };
+
+        if let Err(e) = result {
+            panic!("{}", e)
         }
+        self.is_learner = learner;
         // When a node is first added/promoted, we should mark it as recently active.
         // Otherwise, check_quorum may cause us to step down if it is invoked
         // before the added node has a chance to commuicate with us.
@@ -1901,7 +1888,7 @@ impl<T: Storage> Raft<T> {
         self.mut_prs().remove(id);
 
         // do not try to commit or abort transferring if there are no nodes in the cluster.
-        if self.prs().voters().is_empty() && self.prs().learners().is_empty() {
+        if self.prs().voter_ids().is_empty() && self.prs().learner_ids().is_empty() {
             return;
         }
 
@@ -1918,9 +1905,8 @@ impl<T: Storage> Raft<T> {
 
     /// Updates the progress of the learner or voter.
     pub fn set_progress(&mut self, id: u64, matched: u64, next_idx: u64, is_learner: bool) {
-        let mut p = new_progress(next_idx, self.max_inflight);
+        let mut p = Progress::new(next_idx, self.max_inflight, is_learner);
         p.matched = matched;
-        p.is_learner = is_learner;
         if is_learner {
             if let Err(e) = self.mut_prs().insert_learner(id, p) {
                 panic!("{}", e);

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -354,6 +354,7 @@ impl<T: Storage> Raft<T> {
     }
 
     /// For testing leader lease
+    #[doc(hidden)]
     pub fn set_randomized_election_timeout(&mut self, t: usize) {
         assert!(self.min_election_timeout <= t && t < self.max_election_timeout);
         self.randomized_election_timeout = t;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1864,7 +1864,7 @@ impl<T: Storage> Raft<T> {
             }
         };
 
-        let progress = Progress::new(self.raft_log.last_index(), self.max_inflight, learner);
+        let progress = Progress::new(self.raft_log.last_index() + 1, self.max_inflight, learner);
         let result = if learner {
             self.mut_prs().insert_learner(id, progress)
         } else if self.prs().learner_ids().contains(&id) {
@@ -1876,7 +1876,9 @@ impl<T: Storage> Raft<T> {
         if let Err(e) = result {
             panic!("{}", e)
         }
-        if self.id == id { self.is_learner = learner };
+        if self.id == id {
+            self.is_learner = learner
+        };
         // When a node is first added/promoted, we should mark it as recently active.
         // Otherwise, check_quorum may cause us to step down if it is invoked
         // before the added node has a chance to commuicate with us.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -303,8 +303,8 @@ impl<T: Storage> RawNode<T> {
     pub fn apply_conf_change(&mut self, cc: &ConfChange) -> ConfState {
         if cc.get_node_id() == INVALID_ID {
             let mut cs = ConfState::new();
-            cs.set_nodes(self.raft.prs().nodes());
-            cs.set_learners(self.raft.prs().learner_nodes());
+            cs.set_nodes(self.raft.prs().voter_ids().iter().cloned().collect());
+            cs.set_learners(self.raft.prs().learner_ids().iter().cloned().collect());
             return cs;
         }
         let nid = cc.get_node_id();
@@ -314,8 +314,8 @@ impl<T: Storage> RawNode<T> {
             ConfChangeType::RemoveNode => self.raft.remove_node(nid),
         }
         let mut cs = ConfState::new();
-        cs.set_nodes(self.raft.prs().nodes());
-        cs.set_learners(self.raft.prs().learner_nodes());
+        cs.set_nodes(self.raft.prs().voter_ids().iter().cloned().collect());
+        cs.set_learners(self.raft.prs().learner_ids().iter().cloned().collect());
         cs
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -60,8 +60,12 @@ impl Status {
         s.ss = raft.soft_state();
         s.applied = raft.raft_log.get_applied();
         if s.ss.raft_state == StateRole::Leader {
-            s.progress = raft.prs().voters().clone();
-            s.learner_progress = raft.prs().learners().clone();
+            s.progress = raft.prs().voters().map(|(&k, v)| (k, v.clone())).collect();
+            s.learner_progress = raft
+                .prs()
+                .learners()
+                .map(|(&k, v)| (k, v.clone()))
+                .collect();
         }
         s
     }

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -26,7 +26,7 @@
 // limitations under the License.
 
 use std::cmp;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::panic::{self, AssertUnwindSafe};
 
 use protobuf::{self, RepeatedField};
@@ -303,12 +303,12 @@ fn test_progress_resume_by_heartbeat_resp() {
 
     raft.step(new_message(1, 1, MessageType::MsgBeat, 0))
         .expect("");
-    assert!(raft.prs().voters()[&2].paused);
+    assert!(raft.prs().get(2).unwrap().paused);
 
     raft.mut_prs().get_mut(2).unwrap().become_replicate();
     raft.step(new_message(2, 1, MessageType::MsgHeartbeatResponse, 0))
         .expect("");
-    assert!(!raft.prs().voters()[&2].paused);
+    assert!(!raft.prs().get(2).unwrap().paused);
 }
 
 #[test]
@@ -1140,7 +1140,7 @@ fn test_commit() {
         let mut sm = new_test_raft(1, vec![1], 5, 1, store);
         for (j, &v) in matches.iter().enumerate() {
             let id = j as u64 + 1;
-            if !sm.prs().voters().contains_key(&id) {
+            if !sm.prs().get(id).is_some() {
                 sm.set_progress(id, v, v + 1, false);
             }
         }
@@ -2421,19 +2421,19 @@ fn test_leader_append_response() {
         m.set_reject_hint(index);
         sm.step(m).expect("");
 
-        if sm.prs().voters()[&2].matched != wmatch {
+        if sm.prs().get(2).unwrap().matched != wmatch {
             panic!(
                 "#{}: match = {}, want {}",
                 i,
-                sm.prs().voters()[&2].matched,
+                sm.prs().get(2).unwrap().matched,
                 wmatch
             );
         }
-        if sm.prs().voters()[&2].next_idx != wnext {
+        if sm.prs().get(2).unwrap().next_idx != wnext {
             panic!(
                 "#{}: next = {}, want {}",
                 i,
-                sm.prs().voters()[&2].next_idx,
+                sm.prs().get(2).unwrap().next_idx,
                 wnext
             );
         }
@@ -2496,11 +2496,11 @@ fn test_bcast_beat() {
     let mut want_commit_map = HashMap::new();
     want_commit_map.insert(
         2,
-        cmp::min(sm.raft_log.committed, sm.prs().voters()[&2].matched),
+        cmp::min(sm.raft_log.committed, sm.prs().get(2).unwrap().matched),
     );
     want_commit_map.insert(
         3,
-        cmp::min(sm.raft_log.committed, sm.prs().voters()[&3].matched),
+        cmp::min(sm.raft_log.committed, sm.prs().get(3).unwrap().matched),
     );
     for (i, m) in msgs.drain(..).enumerate() {
         if m.get_msg_type() != MessageType::MsgHeartbeat {
@@ -2597,11 +2597,11 @@ fn test_leader_increase_next() {
         sm.step(new_message(1, 1, MessageType::MsgPropose, 1))
             .expect("");
 
-        if sm.prs().voters()[&2].next_idx != wnext {
+        if sm.prs().get(2).unwrap().next_idx != wnext {
             panic!(
                 "#{}: next = {}, want {}",
                 i,
-                sm.prs().voters()[&2].next_idx,
+                sm.prs().get(2).unwrap().next_idx,
                 wnext
             );
         }
@@ -2630,7 +2630,7 @@ fn test_send_append_for_progress_probe() {
             assert_eq!(msg[0].get_index(), 0);
         }
 
-        assert!(r.prs().voters()[&2].paused);
+        assert!(r.prs().get(2).unwrap().paused);
         for _ in 0..10 {
             r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
             do_send_append(&mut r, 2);
@@ -2642,7 +2642,7 @@ fn test_send_append_for_progress_probe() {
             r.step(new_message(1, 1, MessageType::MsgBeat, 0))
                 .expect("");
         }
-        assert!(r.prs().voters()[&2].paused);
+        assert!(r.prs().get(2).unwrap().paused);
 
         // consume the heartbeat
         let msg = r.read_messages();
@@ -2656,7 +2656,7 @@ fn test_send_append_for_progress_probe() {
     let msg = r.read_messages();
     assert_eq!(msg.len(), 1);
     assert_eq!(msg[0].get_index(), 0);
-    assert!(r.prs().voters()[&2].paused);
+    assert!(r.prs().get(2).unwrap().paused);
 }
 
 #[test]
@@ -2709,11 +2709,9 @@ fn test_recv_msg_unreachable() {
     r.step(new_message(2, 1, MessageType::MsgUnreachable, 0))
         .expect("");
 
-    assert_eq!(r.prs().voters()[&2].state, ProgressState::Probe);
-    assert_eq!(
-        r.prs().voters()[&2].matched + 1,
-        r.prs().voters()[&2].next_idx
-    );
+    let peer_2 = r.prs().get(2).unwrap();
+    assert_eq!(peer_2.state, ProgressState::Probe);
+    assert_eq!(peer_2.matched + 1, peer_2.next_idx);
 }
 
 #[test]
@@ -2730,8 +2728,13 @@ fn test_restore() {
         s.get_metadata().get_term()
     );
     assert_eq!(
-        sm.prs().nodes(),
-        s.get_metadata().get_conf_state().get_nodes()
+        sm.prs().voter_ids().iter().cloned().collect::<HashSet<_>>(),
+        s.get_metadata()
+            .get_conf_state()
+            .get_nodes()
+            .iter()
+            .cloned()
+            .collect(),
     );
     assert!(!sm.restore(s));
 }
@@ -2772,7 +2775,7 @@ fn test_provide_snap() {
     // force set the next of node 2, so that node 2 needs a snapshot
     sm.mut_prs().get_mut(2).unwrap().next_idx = sm.raft_log.first_index();
     let mut m = new_message(2, 1, MessageType::MsgAppendResponse, 0);
-    m.set_index(sm.prs().voters()[&2].next_idx - 1);
+    m.set_index(sm.prs().get(2).unwrap().next_idx - 1);
     m.set_reject(true);
     sm.step(m).expect("");
 
@@ -2831,7 +2834,7 @@ fn test_slow_node_restore() {
     }
     next_ents(&mut nt.peers.get_mut(&1).unwrap(), &nt.storage[&1]);
     let mut cs = ConfState::new();
-    cs.set_nodes(nt.peers[&1].prs().nodes());
+    cs.set_nodes(nt.peers[&1].prs().voter_ids().iter().cloned().collect());
     nt.storage[&1]
         .wl()
         .create_snapshot(nt.peers[&1].raft_log.applied, Some(cs), vec![])
@@ -2846,7 +2849,7 @@ fn test_slow_node_restore() {
     // node 3 will only be considered as active when node 1 receives a reply from it.
     loop {
         nt.send(vec![new_message(1, 1, MessageType::MsgBeat, 0)]);
-        if nt.peers[&1].prs().voters()[&3].recent_active {
+        if nt.peers[&1].prs().get(3).unwrap().recent_active {
             break;
         }
     }
@@ -2939,7 +2942,10 @@ fn test_add_node() {
     setup_for_test();
     let mut r = new_test_raft(1, vec![1], 10, 1, new_storage());
     r.add_node(2);
-    assert_eq!(r.prs().nodes(), vec![1, 2]);
+    assert_eq!(
+        r.prs().voter_ids().iter().cloned().collect::<HashSet<_>>(),
+        vec![1, 2].into_iter().collect()
+    );
 }
 
 #[test]
@@ -2979,11 +2985,14 @@ fn test_remove_node() {
     setup_for_test();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
     r.remove_node(2);
-    assert_eq!(r.prs().nodes(), vec![1]);
+    assert_eq!(
+        r.prs().voter_ids().iter().cloned().collect::<Vec<_>>(),
+        vec![1]
+    );
 
     // remove all nodes from cluster
     r.remove_node(1);
-    assert!(r.prs().nodes().is_empty());
+    assert_eq!(r.prs().voter_ids().len(), 0);
 }
 
 #[test]
@@ -3013,8 +3022,10 @@ fn test_raft_nodes() {
     ];
     for (i, (ids, wids)) in tests.drain(..).enumerate() {
         let r = new_test_raft(1, ids, 10, 1, new_storage());
-        if r.prs().nodes() != wids {
-            panic!("#{}: nodes = {:?}, want {:?}", i, r.prs().nodes(), wids);
+        let voter_ids = r.prs().voter_ids().iter().cloned().collect::<HashSet<_>>();
+        let wids = wids.into_iter().collect();
+        if voter_ids != wids {
+            panic!("#{}: nodes = {:?}, want {:?}", i, voter_ids, wids);
         }
     }
 }
@@ -3187,7 +3198,7 @@ fn test_leader_transfer_to_slow_follower() {
     nt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
 
     nt.recover();
-    assert_eq!(nt.peers[&1].prs().voters()[&3].matched, 1);
+    assert_eq!(nt.peers[&1].prs().get(3).unwrap().matched, 1);
 
     // Transfer leadership to 3 when node 3 is lack of log.
     nt.send(vec![new_message(3, 1, MessageType::MsgTransferLeader, 0)]);
@@ -3206,7 +3217,7 @@ fn test_leader_transfer_after_snapshot() {
     nt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
     next_ents(&mut nt.peers.get_mut(&1).unwrap(), &nt.storage[&1]);
     let mut cs = ConfState::new();
-    cs.set_nodes(nt.peers[&1].prs().nodes());
+    cs.set_nodes(nt.peers[&1].prs().voter_ids().iter().cloned().collect());
     nt.storage[&1]
         .wl()
         .create_snapshot(nt.peers[&1].raft_log.applied, Some(cs), vec![])
@@ -3217,7 +3228,7 @@ fn test_leader_transfer_after_snapshot() {
         .expect("");
 
     nt.recover();
-    assert_eq!(nt.peers[&1].prs().voters()[&3].matched, 1);
+    assert_eq!(nt.peers[&1].prs().get(3).unwrap().matched, 1);
 
     // Transfer leadership to 3 when node 3 is lack of snapshot.
     nt.send(vec![new_message(3, 1, MessageType::MsgTransferLeader, 0)]);
@@ -3300,7 +3311,7 @@ fn test_leader_transfer_ignore_proposal() {
         "should return drop proposal error while transferring"
     );
 
-    assert_eq!(nt.peers[&1].prs().voters()[&1].matched, 1);
+    assert_eq!(nt.peers[&1].prs().get(1).unwrap().matched, 1);
 }
 
 #[test]
@@ -3656,17 +3667,17 @@ fn test_restore_with_learner() {
     assert!(sm.restore(s.clone()));
     assert_eq!(sm.raft_log.last_index(), 11);
     assert_eq!(sm.raft_log.term(11).unwrap(), 11);
-    assert_eq!(sm.prs().voters().len(), 2);
-    assert_eq!(sm.prs().learners().len(), 1);
+    assert_eq!(sm.prs().voters().count(), 2);
+    assert_eq!(sm.prs().learners().count(), 1);
 
-    for node in s.get_metadata().get_conf_state().get_nodes() {
-        assert!(sm.prs().voters().get(node).is_some());
-        assert!(!sm.prs().voters()[node].is_learner);
+    for &node in s.get_metadata().get_conf_state().get_nodes() {
+        assert!(sm.prs().get(node).is_some());
+        assert!(!sm.prs().get(node).unwrap().is_learner);
     }
 
-    for node in s.get_metadata().get_conf_state().get_learners() {
-        assert!(sm.prs().learners().get(node).is_some());
-        assert!(sm.prs().learners()[node].is_learner);
+    for &node in s.get_metadata().get_conf_state().get_learners() {
+        assert!(sm.prs().get(node).is_some());
+        assert!(sm.prs().get(node).unwrap().is_learner);
     }
 
     assert!(!sm.restore(s));
@@ -3742,8 +3753,11 @@ fn test_add_learner() {
     let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage());
     n1.add_learner(2);
 
-    assert_eq!(n1.prs().learner_nodes(), vec![2]);
-    assert!(n1.prs().learners()[&2].is_learner);
+    assert_eq!(
+        n1.prs().learner_ids().iter().cloned().collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert!(n1.prs().get(2).unwrap().is_learner);
 }
 
 // TestRemoveLearner tests that removeNode could update nodes and
@@ -3753,12 +3767,18 @@ fn test_remove_learner() {
     setup_for_test();
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage());
     n1.remove_node(2);
-    assert_eq!(n1.prs().nodes(), vec![1]);
-    assert_eq!(n1.prs().learner_nodes(), vec![]);
+    assert_eq!(
+        n1.prs().voter_ids().iter().cloned().collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        n1.prs().learner_ids().iter().cloned().collect::<Vec<_>>(),
+        vec![]
+    );
 
     n1.remove_node(1);
-    assert!(n1.prs().nodes().is_empty());
-    assert!(n1.prs().learner_nodes().is_empty());
+    assert_eq!(n1.prs().voter_ids().len(), 0);
+    assert_eq!(n1.prs().learner_ids().len(), 0);
 }
 
 // simulate rolling update a cluster for Pre-Vote. cluster has 3 nodes [n1, n2, n3].

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -2986,10 +2986,7 @@ fn test_remove_node() {
     setup_for_test();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage());
     r.remove_node(2);
-    assert_eq!(
-        r.prs().voter_ids().iter().next().unwrap(),
-        &1
-    );
+    assert_eq!(r.prs().voter_ids().iter().next().unwrap(), &1);
 
     // remove all nodes from cluster
     r.remove_node(1);
@@ -3754,10 +3751,7 @@ fn test_add_learner() {
     let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage());
     n1.add_learner(2);
 
-    assert_eq!(
-        n1.prs().learner_ids().iter().next().unwrap(),
-        &2
-    );
+    assert_eq!(n1.prs().learner_ids().iter().next().unwrap(), &2);
     assert!(n1.prs().get(2).unwrap().is_learner);
 }
 
@@ -3768,10 +3762,7 @@ fn test_remove_learner() {
     setup_for_test();
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage());
     n1.remove_node(2);
-    assert_eq!(
-        n1.prs().voter_ids().iter().next().unwrap(),
-        &1
-    );
+    assert_eq!(n1.prs().voter_ids().iter().next().unwrap(), &1);
     assert!(n1.prs().learner_ids().is_empty());
 
     n1.remove_node(1);

--- a/tests/integration_cases/test_raft_flow_control.rs
+++ b/tests/integration_cases/test_raft_flow_control.rs
@@ -51,7 +51,7 @@ fn test_msg_app_flow_control_full() {
     }
 
     // ensure 1
-    assert!(r.prs().voters()[&2].ins.full());
+    assert!(r.prs().get(2).unwrap().ins.full());
 
     // ensure 2
     for i in 0..10 {
@@ -102,18 +102,18 @@ fn test_msg_app_flow_control_move_forward() {
         }
 
         // ensure 1
-        assert!(r.prs().voters()[&2].ins.full());
+        assert!(r.prs().get(2).unwrap().ins.full());
 
         // ensure 2
         for i in 0..tt {
             let mut m = new_message(2, 1, MessageType::MsgAppendResponse, 0);
             m.set_index(i as u64);
             r.step(m).expect("");
-            if !r.prs().voters()[&2].ins.full() {
+            if !r.prs().get(2).unwrap().ins.full() {
                 panic!(
                     "#{}: inflights.full = {}, want true",
                     tt,
-                    r.prs().voters()[&2].ins.full()
+                    r.prs().get(2).unwrap().ins.full()
                 );
             }
         }
@@ -139,11 +139,11 @@ fn test_msg_app_flow_control_recv_heartbeat() {
     }
 
     for tt in 1..5 {
-        if !r.prs().voters()[&2].ins.full() {
+        if !r.prs().get(2).unwrap().ins.full() {
             panic!(
                 "#{}: inflights.full = {}, want true",
                 tt,
-                r.prs().voters()[&2].ins.full()
+                r.prs().get(2).unwrap().ins.full()
             );
         }
 
@@ -152,12 +152,12 @@ fn test_msg_app_flow_control_recv_heartbeat() {
             r.step(new_message(2, 1, MessageType::MsgHeartbeatResponse, 0))
                 .expect("");
             r.read_messages();
-            if r.prs().voters()[&2].ins.full() {
+            if r.prs().get(2).unwrap().ins.full() {
                 panic!(
                     "#{}.{}: inflights.full = {}, want false",
                     tt,
                     i,
-                    r.prs().voters()[&2].ins.full()
+                    r.prs().get(2).unwrap().ins.full()
                 );
             }
         }

--- a/tests/integration_cases/test_raft_snap.rs
+++ b/tests/integration_cases/test_raft_snap.rs
@@ -46,10 +46,13 @@ fn test_sending_snapshot_set_pending_snapshot() {
     sm.mut_prs().get_mut(2).unwrap().next_idx = sm.raft_log.first_index();
 
     let mut m = new_message(2, 1, MessageType::MsgAppendResponse, 0);
-    m.set_index(sm.prs().voters()[&2].next_idx - 1);
-    m.set_reject(true);
+    {
+        let voter_2 = sm.prs().get(2).unwrap();
+        m.set_index(voter_2.next_idx - 1);
+        m.set_reject(true);
+    };
     sm.step(m).expect("");
-    assert_eq!(sm.prs().voters()[&2].pending_snapshot, 11);
+    assert_eq!(sm.prs().get(2).unwrap().pending_snapshot, 11);
 }
 
 #[test]
@@ -83,9 +86,10 @@ fn test_snapshot_failure() {
     let mut m = new_message(2, 1, MessageType::MsgSnapStatus, 0);
     m.set_reject(true);
     sm.step(m).expect("");
-    assert_eq!(sm.prs().voters()[&2].pending_snapshot, 0);
-    assert_eq!(sm.prs().voters()[&2].next_idx, 1);
-    assert!(sm.prs().voters()[&2].paused);
+    let voter_2 = sm.prs().get(2).unwrap();
+    assert_eq!(voter_2.pending_snapshot, 0);
+    assert_eq!(voter_2.next_idx, 1);
+    assert!(voter_2.paused);
 }
 
 #[test]
@@ -103,9 +107,10 @@ fn test_snapshot_succeed() {
     let mut m = new_message(2, 1, MessageType::MsgSnapStatus, 0);
     m.set_reject(false);
     sm.step(m).expect("");
-    assert_eq!(sm.prs().voters()[&2].pending_snapshot, 0);
-    assert_eq!(sm.prs().voters()[&2].next_idx, 12);
-    assert!(sm.prs().voters()[&2].paused);
+    let voter_2 = sm.prs().get(2).unwrap();
+    assert_eq!(voter_2.pending_snapshot, 0);
+    assert_eq!(voter_2.next_idx, 12);
+    assert!(voter_2.paused);
 }
 
 #[test]
@@ -125,6 +130,6 @@ fn test_snapshot_abort() {
     // A successful MsgAppendResponse that has a higher/equal index than the
     // pending snapshot should abort the pending snapshot.
     sm.step(m).expect("");
-    assert_eq!(sm.prs().voters()[&2].pending_snapshot, 0);
-    assert_eq!(sm.prs().voters()[&2].next_idx, 12);
+    assert_eq!(sm.prs().get(2).unwrap().pending_snapshot, 0);
+    assert_eq!(sm.prs().get(2).unwrap().next_idx, 12);
 }

--- a/tests/test_util/mod.rs
+++ b/tests/test_util/mod.rs
@@ -100,9 +100,12 @@ impl Interface {
         if self.raft.is_some() {
             self.id = id;
             let prs = self.take_prs();
-            self.set_prs(ProgressSet::new(ids.len(), prs.learners().len()));
+            self.set_prs(ProgressSet::with_capacity(
+                ids.len(),
+                prs.learner_ids().len(),
+            ));
             for id in ids {
-                if prs.learners().contains_key(id) {
+                if prs.learner_ids().contains(id) {
                     let progress = Progress {
                         is_learner: true,
                         ..Default::default()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -25,6 +25,7 @@ extern crate rand;
 extern crate lazy_static;
 #[cfg(feature = "failpoint")]
 extern crate fail;
+extern crate fxhash;
 
 /// Get the count of macro's arguments.
 ///


### PR DESCRIPTION
The motivation for this PR may be unclear until you consider future work. But, shortly, this is partially in preparation for Joint Consensus.

This is a step to allowing us to use different configurations (eg voter/learner topology) on top of the same Progress states. This will mean we can have `ProgressSet` be aware of its peer set changing, and able to have calls like `self.prs().voters()` or `self.prs().learner_nodes()` always remain accurate.

# Rationale

Currently we store `Progress` data, which are of a non-trivial size, in two `FxHashMap`s in `ProgressSet`. They are holding voters and learners respectively. During `add_node()`, `add_learner()`, `remove_node()`, and `promote_learner()` we currently check sometimes multiple HashMaps, and at times need to move `Progress` values between maps. **We don't need to do this.**

Typical use cases for `ProgressSet` include iterating over these peers (such as `self.prs().voters()`), fetching individual peers (such as `self.prs().voters().get(id)`), checking membership (`self.prs().voters().contains_key()`), removing nodes (either role), adding voters, adding learners, promoting learners, or removing learners.

Scanning the entire set is done by chaining iterators over the two hashmaps already, so storing them in a single HashMap has no penalty. Returning Iterators where possible instead of realized structures means we can possibly save on allocations (you can do `self.prs().voters().any(_)` faster now).

Scanning over a specific subset (eg voter, learner) is slightly slower since the iterator returned is internally filtering out non-voter/non-learners. Since most node sets are fairly small, and the check is a simple bool, this performance change is not dramatic. (This can be possibly optimized, but I'm not sure it's worth the complexity).

Fetching individual nodes was optimized since it is always a lookup now, not possibly two lookups (in the case of getting a node without the specifier).

Removing nodes should also be faster (single lookup).

Promoting Learners now is just changing a boolean (but this will likely change later for Joint Consensus).

# Future Work

In the next PR my thought is to introduce `poll` and `quorum` logic to `ProgressSet`, instead of being in `Raft` (`Raft` can still proxy to them). Why? When we enter a joint consensus (#101 ) state we no longer can just check if `# of votes >= quorum`. The cluster needs to account for the votes of nodes in **two separate configurations**. So the check for elections is `# of votes >= quorum` **or** `(# votes_old >= quorum_old) && (# votes_new >= quorum_new)` depending on the state of the system.

I'd like to follow with a PR to have `ProgressSet` hold a `ConfState` (a vec of voters, and a
vec of learners in a protobuf), and this `FxHashMap<u64, Progress>` that `ProgressSet` already
holds. This will allow us to in the future use an enum inside the
`ProgressSet`:

```rust
enum Configuration {
    Stable(ConfState),
    Joint { old: ConfState, new: ConfState },
}
```

It may be wise to use a different datatype for the `ConfStates` than the protobuf though. This needs to be explored. Perhaps a `FxHashMap<u64, Weak<Progress>>` pointing back into the actual Progress, so we can just follow the pointer.

This will allow us to quickly pass lists of IDs to callers and compose iterators of progress with chains, mapping into the HashMap. (If we do this, the Weak/Rc idea above is more compelling perhaps).

# Performance Impact

There were no major performance impacts. A few benchmarks were slightly slower or slightly faster, but no remarkable impacts. Note many tests are a small % slower due to the additional allocation involved since we're now holding a bit of extra data.


```
   Compiling raft v0.3.1 (file:///home/hoverbear/git/raft-rs)
    Finished release [optimized] target(s) in 7.01s
     Running target/release/deps/benches-b3f4a3ccb54b1af9
Raft::new (0, 0)        time:   [654.68 ns 658.33 ns 663.60 ns]                              
                        change: [+2.4424% +4.1041% +5.5835%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

Raft::new (3, 1)        time:   [1.0552 us 1.0571 us 1.0592 us]                              
                        change: [+5.3398% +7.4368% +9.4033%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe

Raft::new (5, 2)        time:   [1.2448 us 1.2469 us 1.2492 us]                              
                        change: [+3.0618% +5.4548% +7.7207%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 18 outliers among 100 measurements (18.00%)
  9 (9.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

Raft::new (7, 3)        time:   [1.5091 us 1.5169 us 1.5285 us]                              
                        change: [+6.9430% +8.0638% +9.3565%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

Raft::campaign (3, 1, CampaignPreElection)                                                                             
                        time:   [1.6698 us 1.6796 us 1.6914 us]
                        change: [+7.1247% +8.9953% +11.082%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

Raft::campaign (3, 1, CampaignElection)                                                                             
                        time:   [1.8421 us 1.8543 us 1.8701 us]
                        change: [-0.7334% +0.9614% +2.9925%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Raft::campaign (3, 1, CampaignTransfer)                                                                             
                        time:   [1.9347 us 1.9791 us 2.0401 us]
                        change: [+4.6167% +6.8336% +9.7574%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

Raft::campaign (5, 2, CampaignPreElection)                                                                             
                        time:   [2.3698 us 2.3725 us 2.3759 us]
                        change: [-0.5268% +0.8138% +2.1554%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Raft::campaign (5, 2, CampaignElection)                                                                             
                        time:   [2.5981 us 2.6072 us 2.6228 us]
                        change: [+5.1047% +6.6554% +8.2343%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

Raft::campaign (5, 2, CampaignTransfer)                                                                             
                        time:   [2.7336 us 2.7424 us 2.7546 us]
                        change: [-2.8336% -1.6015% -0.2993%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

Raft::campaign (7, 3, CampaignPreElection)                                                                             
                        time:   [3.0390 us 3.0577 us 3.0808 us]
                        change: [+6.2413% +8.4249% +10.575%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Raft::campaign (7, 3, CampaignElection)                                                                             
                        time:   [3.3627 us 3.3815 us 3.4033 us]
                        change: [+3.5173% +5.6968% +7.8047%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

Raft::campaign (7, 3, CampaignTransfer)                                                                             
                        time:   [3.5182 us 3.5326 us 3.5498 us]
                        change: [+0.1086% +1.5806% +3.0729%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

RawNode::new            time:   [957.90 ns 962.74 ns 968.28 ns]                          
                        change: [+0.4930% +2.1651% +3.6894%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Progress::default       time:   [2.7608 ns 2.7694 ns 2.7820 ns]                               
                        change: [+3.4533% +4.0793% +4.7229%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

ProgressSet::new (0, 0) time:   [24.331 ns 24.464 ns 24.622 ns]                                    
                        change: [+12.726% +13.755% +14.741%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::new (3, 1) time:   [77.597 ns 77.870 ns 78.208 ns]                                    
                        change: [+4.2794% +5.0575% +5.8202%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

ProgressSet::new (5, 2) time:   [78.236 ns 78.473 ns 78.770 ns]                                    
                        change: [+4.1984% +5.2535% +6.2644%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

ProgressSet::new (7, 3) time:   [78.297 ns 78.467 ns 78.690 ns]                                    
                        change: [+3.2772% +4.1558% +5.3449%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

ProgressSet::insert_voter (0, 0)                                                                            
                        time:   [82.880 ns 83.059 ns 83.289 ns]
                        change: [-2.3601% -1.5005% -0.6649%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

ProgressSet::insert_voter (3, 1)                                                                             
                        time:   [195.68 ns 196.88 ns 198.43 ns]
                        change: [+3.8072% +5.1527% +6.6821%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

ProgressSet::insert_voter (5, 2)                                                                             
                        time:   [238.59 ns 240.82 ns 243.56 ns]
                        change: [+9.6677% +11.744% +13.744%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

ProgressSet::insert_voter (7, 3)                                                                             
                        time:   [250.93 ns 252.21 ns 253.76 ns]
                        change: [+9.5544% +10.656% +11.673%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::insert_learner (0, 0)                                                                             
                        time:   [84.346 ns 84.675 ns 85.032 ns]
                        change: [+4.0566% +5.3939% +6.6914%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

ProgressSet::insert_learner (3, 1)                                                                             
                        time:   [194.62 ns 195.77 ns 197.10 ns]
                        change: [+8.5062% +9.9784% +11.317%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::insert_learner (5, 2)                                                                             
                        time:   [216.15 ns 217.55 ns 219.23 ns]
                        change: [+9.6463% +11.074% +12.443%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

ProgressSet::insert_learner (7, 3)                                                                             
                        time:   [236.09 ns 237.22 ns 238.59 ns]
                        change: [+6.0486% +7.3821% +8.6658%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

ProgressSet::promote (0, 0)                                                                            
                        time:   [30.150 ns 30.321 ns 30.517 ns]
                        change: [-0.8956% +0.9434% +2.8369%] (p = 0.32 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

ProgressSet::promote (3, 1)                                                                             
                        time:   [174.10 ns 174.50 ns 175.02 ns]
                        change: [-1.6114% +0.7134% +2.4685%] (p = 0.57 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

ProgressSet::promote (5, 2)                                                                             
                        time:   [206.81 ns 207.74 ns 208.90 ns]
                        change: [+12.212% +13.224% +14.202%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::promote (7, 3)                                                                             
                        time:   [225.56 ns 227.15 ns 229.03 ns]
                        change: [-0.7211% +1.0632% +2.8948%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

ProgressSet::remove (0, 0)                                                                            
                        time:   [65.105 ns 65.554 ns 66.085 ns]
                        change: [+8.8515% +10.210% +11.544%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::remove (3, 1)                                                                             
                        time:   [210.29 ns 211.60 ns 213.16 ns]
                        change: [+7.3192% +8.9684% +10.540%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::remove (5, 2)                                                                             
                        time:   [312.97 ns 319.75 ns 327.84 ns]
                        change: [+40.410% +43.287% +45.910%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::remove (7, 3)                                                                             
                        time:   [292.14 ns 294.15 ns 296.60 ns]
                        change: [+22.410% +23.951% +25.465%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

ProgressSet::iter (0, 0)                                                                            
                        time:   [32.426 ns 32.682 ns 32.986 ns]
                        change: [+19.914% +21.344% +22.678%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::iter (3, 1)                                                                             
                        time:   [215.07 ns 217.18 ns 219.64 ns]
                        change: [+24.669% +26.020% +27.425%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

ProgressSet::iter (5, 2)                                                                             
                        time:   [232.52 ns 234.99 ns 237.96 ns]
                        change: [+18.472% +20.308% +21.988%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

ProgressSet::iter (7, 3)                                                                             
                        time:   [255.43 ns 262.34 ns 272.19 ns]
                        change: [+14.089% +16.026% +18.440%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

ProgressSet::get (0, 0) time:   [24.563 ns 24.764 ns 25.007 ns]                                    
                        change: [+19.712% +21.106% +22.553%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::get (3, 1) time:   [178.88 ns 180.24 ns 181.89 ns]                                     
                        change: [+17.606% +19.109% +20.784%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

ProgressSet::get (5, 2) time:   [198.47 ns 199.85 ns 201.50 ns]                                     
                        change: [+17.484% +18.857% +20.212%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::get (7, 3) time:   [222.11 ns 223.86 ns 226.02 ns]                                     
                        change: [+8.8628% +10.119% +11.473%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::nodes (0, 0)                                                                            
                        time:   [30.588 ns 30.741 ns 30.935 ns]
                        change: [+12.690% +14.065% +15.416%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::nodes (3, 1)                                                                             
                        time:   [199.91 ns 201.45 ns 203.25 ns]
                        change: [+12.052% +13.444% +14.856%] (p = 0.00 < 0.05)
                        Performance has regressed.

ProgressSet::nodes (5, 2)                                                                             
                        time:   [231.50 ns 233.10 ns 235.04 ns]
                        change: [+9.1243% +10.754% +12.436%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

ProgressSet::nodes (7, 3)                                                                             
                        time:   [250.84 ns 252.33 ns 254.05 ns]
                        change: [+2.3537% +3.7544% +5.0726%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

```