### PR TITLE
support skip bcast commit at run time

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -389,6 +389,12 @@ impl<T: Storage> Raft<T> {
         self.randomized_election_timeout
     }
 
+    /// Set whether skip broadcast empty commit messages at runtime.
+    #[inline]
+    pub fn skip_bcast_commit(&mut self, skip: bool) {
+        self.skip_bcast_commit = skip;
+    }
+
     // send persists state to stable storage and then sends to its mailbox.
     fn send(&mut self, mut m: Message) {
         m.set_from(self.id);

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -474,6 +474,12 @@ impl<T: Storage> RawNode<T> {
     pub fn mut_store(&mut self) -> &mut T {
         self.raft.mut_store()
     }
+
+    /// Set whether skip broadcast empty commit messages at runtime.
+    #[inline]
+    pub fn skip_bcast_commit(&mut self, skip: bool) {
+        self.raft.skip_bcast_commit(skip)
+    }
 }
 
 #[cfg(test)]

--- a/tests/cases/test_raw_node.rs
+++ b/tests/cases/test_raw_node.rs
@@ -497,12 +497,21 @@ fn test_skip_bcast_commit() {
     assert_eq!(nt.peers[&2].raft_log.committed, 2);
     assert_eq!(nt.peers[&3].raft_log.committed, 2);
 
+    // The feature should be able to be adjusted at run time.
+    nt.peers.get_mut(&1).unwrap().skip_bcast_commit(false);
+    nt.send(vec![msg.clone()]);
+    assert_eq!(nt.peers[&1].raft_log.committed, 3);
+    assert_eq!(nt.peers[&2].raft_log.committed, 3);
+    assert_eq!(nt.peers[&3].raft_log.committed, 3);
+
+    nt.peers.get_mut(&1).unwrap().skip_bcast_commit(true);
+
     // Later proposal should commit former proposal.
     nt.send(vec![msg.clone()]);
     nt.send(vec![msg]);
-    assert_eq!(nt.peers[&1].raft_log.committed, 4);
-    assert_eq!(nt.peers[&2].raft_log.committed, 3);
-    assert_eq!(nt.peers[&3].raft_log.committed, 3);
+    assert_eq!(nt.peers[&1].raft_log.committed, 5);
+    assert_eq!(nt.peers[&2].raft_log.committed, 4);
+    assert_eq!(nt.peers[&3].raft_log.committed, 4);
 
     // When committing conf change, leader should always bcast commit.
     let mut cc_entry = Entry::new();
@@ -517,7 +526,7 @@ fn test_skip_bcast_commit() {
     assert!(nt.peers[&2].should_bcast_commit());
     assert!(nt.peers[&3].should_bcast_commit());
 
-    assert_eq!(nt.peers[&1].raft_log.committed, 5);
-    assert_eq!(nt.peers[&2].raft_log.committed, 5);
-    assert_eq!(nt.peers[&3].raft_log.committed, 5);
+    assert_eq!(nt.peers[&1].raft_log.committed, 6);
+    assert_eq!(nt.peers[&2].raft_log.committed, 6);
+    assert_eq!(nt.peers[&3].raft_log.committed, 6);
 }


### PR DESCRIPTION
Only users know whether a message needs to be commit eagerly. So provide a way
to configure the feature at run time.

Another way to fix this is to add a new option to propose method. However this will
require a change to the protobuf and existing API.

This PR is trying to provide a way to fix the problem described in tikv/tikv#3578.