### PR TITLE
Remove Progress.is_learner

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -717,20 +717,6 @@ mod test_progress_set {
     }
 
     #[test]
-    fn test_promote_learner_does_not_exist() -> Result<()> {
-        let mut set = ProgressSet::default();
-        assert!(
-            set.promote_learner(1).is_err(),
-            "Should return an error on invalid voter insert."
-        );
-        assert!(
-            set.get(1).is_none(),
-            "Should not have inserted a node on invalid promote_learner."
-        );
-        Ok(())
-    }
-
-    #[test]
     fn test_promote_learner_already_voter() -> Result<()> {
         let mut set = ProgressSet::default();
         let default_progress = Progress::default();
@@ -738,6 +724,10 @@ mod test_progress_set {
         let pre = set.get(1).expect("Should have been inserted").clone();
         assert!(
             set.promote_learner(1).is_err(),
+            "Should return an error on invalid promote_learner."
+        );
+        assert!(
+            set.promote_learner(2).is_err(),
             "Should return an error on invalid promote_learner."
         );
         assert_eq!(pre, *set.get(1).expect("Peer should not have been deleted"));

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -229,7 +229,7 @@ impl ProgressSet {
 }
 
 /// The progress of catching up from a restart.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Progress {
     /// How much state is matched.
     pub matched: u64,
@@ -620,5 +620,127 @@ mod test {
         };
 
         assert_eq!(inflight, wantin);
+    }
+}
+
+// TODO: Reorganize this whole file into separate files.
+// See https://github.com/pingcap/raft-rs/issues/125
+#[cfg(test)]
+mod test_progress_set {
+    use Result;
+    use {Progress, ProgressSet};
+
+    const CANARY: u64 = 123;
+
+    #[test]
+    fn test_insert_redundant_voter() -> Result<()> {
+        let mut set = ProgressSet::default();
+        let default_progress = Progress::default();
+        let canary_progress = Progress {
+            matched: CANARY,
+            ..Default::default()
+        };
+        set.insert_voter(1, default_progress.clone())?;
+        assert!(
+            set.insert_voter(1, canary_progress).is_err(),
+            "Should return an error on redundant insert."
+        );
+        assert_eq!(
+            *set.get(1).expect("Should be inserted."),
+            default_progress,
+            "The ProgressSet was mutated in a `insert_voter` that returned error."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_redundant_learner() -> Result<()> {
+        let mut set = ProgressSet::default();
+        let default_progress = Progress::default();
+        let canary_progress = Progress {
+            matched: CANARY,
+            ..Default::default()
+        };
+        set.insert_voter(1, default_progress.clone())?;
+        assert!(
+            set.insert_voter(1, canary_progress).is_err(),
+            "Should return an error on redundant insert."
+        );
+        assert_eq!(
+            *set.get(1).expect("Should be inserted."),
+            default_progress,
+            "The ProgressSet was mutated in a `insert_learner` that returned error."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_learner_that_is_voter() -> Result<()> {
+        let mut set = ProgressSet::default();
+        let default_progress = Progress::default();
+        let canary_progress = Progress {
+            matched: CANARY,
+            ..Default::default()
+        };
+        set.insert_voter(1, default_progress.clone())?;
+        assert!(
+            set.insert_learner(1, canary_progress).is_err(),
+            "Should return an error on invalid learner insert."
+        );
+        assert_eq!(
+            *set.get(1).expect("Should be inserted."),
+            default_progress,
+            "The ProgressSet was mutated in a `insert_learner` that returned error."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_voter_that_is_learner() -> Result<()> {
+        let mut set = ProgressSet::default();
+        let default_progress = Progress::default();
+        let canary_progress = Progress {
+            matched: CANARY,
+            ..Default::default()
+        };
+        set.insert_learner(1, default_progress.clone())?;
+        assert!(
+            set.insert_voter(1, canary_progress).is_err(),
+            "Should return an error on invalid voter insert."
+        );
+        assert_eq!(
+            *set.get(1).expect("Should be inserted."),
+            default_progress,
+            "The ProgressSet was mutated in a `insert_voter` that returned error."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_promote_learner_does_not_exist() -> Result<()> {
+        let mut set = ProgressSet::default();
+        assert!(
+            set.promote_learner(1).is_err(),
+            "Should return an error on invalid voter insert."
+        );
+        assert!(
+            set.get(1).is_none(),
+            "Should not have inserted a node on invalid promote_learner."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_promote_learner_already_voter() -> Result<()> {
+        let mut set = ProgressSet::default();
+        let default_progress = Progress::default();
+        set.insert_voter(1, default_progress)?;
+        let pre = set.get(1).expect("Should have been inserted").clone();
+        assert!(
+            set.promote_learner(1).is_err(),
+            "Should return an error on invalid promote_learner."
+        );
+        assert_eq!(pre, *set.get(1).expect("Peer should not have been deleted"));
+        Ok(())
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -195,13 +195,13 @@ impl ProgressSet {
 
     /// Promote a learner to a peer.
     pub fn promote_learner(&mut self, id: u64) -> Result<(), Error> {
-        if self.learner_ids().contains(&id) {
-            self.configuration.voters.insert(id);
-            self.configuration.learners.remove(&id);
-        } else if self.voter_ids().contains(&id) {
+        if !self.configuration.learners.remove(&id) {
+            // Wasn't already a voter. We can't promote what doesn't exist.
+            return Err(Error::Exists(id, "learners"));
+        }
+        if !self.configuration.voters.insert(id) {
+            // Already existed, the caller should know this was a noop.
             return Err(Error::Exists(id, "voters"));
-        } else {
-            return Err(Error::NotExists(id, "learners"));
         }
         self.assert_progress_and_configuration_consistent();
         Ok(())

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -195,14 +195,11 @@ impl ProgressSet {
 
     /// Promote a learner to a peer.
     pub fn promote_learner(&mut self, id: u64) -> Result<(), Error> {
-        let is_learner = self.learner_ids().contains(&id);
-        let is_voter = self.voter_ids().contains(&id);
-
-        if is_voter {
-            return Err(Error::Exists(id, "voters"));
-        } else if is_learner {
+        if self.learner_ids().contains(&id) {
             self.configuration.voters.insert(id);
             self.configuration.learners.remove(&id);
+        } else if self.voter_ids().contains(&id) {
+            return Err(Error::Exists(id, "voters"));
         } else {
             return Err(Error::NotExists(id, "learners"));
         }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -661,9 +661,9 @@ mod test_progress_set {
             matched: CANARY,
             ..Default::default()
         };
-        set.insert_voter(1, default_progress.clone())?;
+        set.insert_learner(1, default_progress.clone())?;
         assert!(
-            set.insert_voter(1, canary_progress).is_err(),
+            set.insert_learner(1, canary_progress).is_err(),
             "Should return an error on redundant insert."
         );
         assert_eq!(

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -196,8 +196,8 @@ impl ProgressSet {
     /// Promote a learner to a peer.
     pub fn promote_learner(&mut self, id: u64) -> Result<(), Error> {
         if !self.configuration.learners.remove(&id) {
-            // Wasn't already a voter. We can't promote what doesn't exist.
-            return Err(Error::Exists(id, "learners"));
+            // Wasn't already a learner. We can't promote what doesn't exist.
+            return Err(Error::NotExists(id, "learners"));
         }
         if !self.configuration.voters.insert(id) {
             // Already existed, the caller should know this was a noop.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -717,20 +717,24 @@ mod test_progress_set {
     }
 
     #[test]
-    fn test_promote_learner_already_voter() -> Result<()> {
+    fn test_promote_learner() -> Result<()> {
         let mut set = ProgressSet::default();
         let default_progress = Progress::default();
         set.insert_voter(1, default_progress)?;
         let pre = set.get(1).expect("Should have been inserted").clone();
         assert!(
             set.promote_learner(1).is_err(),
-            "Should return an error on invalid promote_learner."
+            "Should return an error on promote_learner on a peer that is a voter."
         );
+        // Not yet added.
         assert!(
             set.promote_learner(2).is_err(),
-            "Should return an error on invalid promote_learner."
+            "Should return an error on promote_learner on a non-existing peer.."
         );
-        assert_eq!(pre, *set.get(1).expect("Peer should not have been deleted"));
+        assert_eq!(
+            pre,
+            *set.get(1).expect("Peer should not have been promoted")
+        );
         Ok(())
     }
 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1986,9 +1986,11 @@ impl<T: Storage> Raft<T> {
 
         self.prs = if let Some(mut prs) = self.prs.take() {
             for (&id, pr) in prs.voters_mut() {
-                if id == self_id || pr.recent_active {
+                if id == self_id {
                     act += 1;
+                    continue;
                 }
+                if pr.recent_active { act += 1; }
                 pr.recent_active = false;
             }
             for (&_id, pr) in prs.learners_mut() {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1869,7 +1869,7 @@ impl<T: Storage> Raft<T> {
         // Otherwise, check_quorum may cause us to step down if it is invoked
         // before the added node has a chance to commuicate with us.
         self.mut_prs().get_mut(id).unwrap().recent_active = true;
-        return result;
+        result
     }
 
     /// Adds a new node to the cluster.
@@ -1994,7 +1994,9 @@ impl<T: Storage> Raft<T> {
                 pr.recent_active = false;
             }
             Some(prs)
-        } else { unreachable!() };
+        } else {
+            unreachable!()
+        };
 
         act >= self.quorum()
     }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1988,7 +1988,6 @@ impl<T: Storage> Raft<T> {
             for (&id, pr) in prs.voters_mut() {
                 if id == self_id || pr.recent_active {
                     act += 1;
-                    continue;
                 }
                 pr.recent_active = false;
             }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1843,38 +1843,24 @@ impl<T: Storage> Raft<T> {
         self.prs().voter_ids().contains(&self.id)
     }
 
-    fn add_voter_or_learner(&mut self, id: u64, learner: bool) {
+    fn add_voter_or_learner(&mut self, id: u64, learner: bool) -> Result<()> {
         debug!(
             "Adding node (learner: {}) with ID {} to peers.",
             learner, id
         );
 
-        // Ignore redundant inserts.
-        // TODO: Remove these and have this function and related functions return errors.
-        if self.prs().get(id).is_some() {
-            // If progress is a learner, then it's already inserted as what it should be, return early to avoid error.
-            if self.prs().learner_ids().contains(&id) == learner {
-                info!("{} Ignoring redundant insert of ID {}.", self.tag, id);
-                return;
-            }
-            // If progress is a voter, and learner == true, then it's a demotion, return early to avoid an error.
-            if self.prs().voter_ids().contains(&id) && learner {
-                info!("{} Ignoring voter demotion of ID {}.", self.tag, id);
-                return;
-            }
-        };
-
-        let progress = Progress::new(self.raft_log.last_index() + 1, self.max_inflight);
         let result = if learner {
+            let progress = Progress::new(self.raft_log.last_index() + 1, self.max_inflight);
             self.mut_prs().insert_learner(id, progress)
         } else if self.prs().learner_ids().contains(&id) {
             self.mut_prs().promote_learner(id)
         } else {
+            let progress = Progress::new(self.raft_log.last_index() + 1, self.max_inflight);
             self.mut_prs().insert_voter(id, progress)
         };
 
-        if let Err(e) = result {
-            panic!("{}", e)
+        if let Err(ref e) = result {
+            error!("{}", e);
         }
         if self.id == id {
             self.is_learner = learner
@@ -1883,16 +1869,19 @@ impl<T: Storage> Raft<T> {
         // Otherwise, check_quorum may cause us to step down if it is invoked
         // before the added node has a chance to commuicate with us.
         self.mut_prs().get_mut(id).unwrap().recent_active = true;
+        return result;
     }
 
     /// Adds a new node to the cluster.
+    // TODO: Return an error on a redundant insert.
     pub fn add_node(&mut self, id: u64) {
-        self.add_voter_or_learner(id, false);
+        self.add_voter_or_learner(id, false).ok();
     }
 
     /// Adds a learner node.
+    // TODO: Return an error on a redundant insert.
     pub fn add_learner(&mut self, id: u64) {
-        self.add_voter_or_learner(id, true);
+        self.add_voter_or_learner(id, true).ok();
     }
 
     /// Removes a node from the raft.
@@ -1993,17 +1982,20 @@ impl<T: Storage> Raft<T> {
     fn check_quorum_active(&mut self) -> bool {
         let self_id = self.id;
         let mut act = 0;
-        let learners = self.prs().learner_ids().clone();
-        for (&id, pr) in self.mut_prs().iter_mut() {
-            if id == self_id {
-                act += 1;
-                continue;
+
+        self.prs = if let Some(mut prs) = self.prs.take() {
+            for (&id, pr) in prs.voters_mut() {
+                if id == self_id || pr.recent_active {
+                    act += 1;
+                }
+                pr.recent_active = false;
             }
-            if !learners.contains(&id) && pr.recent_active {
-                act += 1;
+            for (&_id, pr) in prs.learners_mut() {
+                pr.recent_active = false;
             }
-            pr.recent_active = false;
-        }
+            Some(prs)
+        } else { unreachable!() };
+
         act >= self.quorum()
     }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1859,8 +1859,9 @@ impl<T: Storage> Raft<T> {
             self.mut_prs().insert_voter(id, progress)
         };
 
-        if let Err(ref e) = result {
+        if let Err(e) = result {
             error!("{}", e);
+            return Err(e);
         }
         if self.id == id {
             self.is_learner = learner
@@ -1987,6 +1988,7 @@ impl<T: Storage> Raft<T> {
             for (&id, pr) in prs.voters_mut() {
                 if id == self_id || pr.recent_active {
                     act += 1;
+                    continue;
                 }
                 pr.recent_active = false;
             }
@@ -1995,7 +1997,7 @@ impl<T: Storage> Raft<T> {
             }
             Some(prs)
         } else {
-            unreachable!()
+            unreachable!("Invariant: ProgressSet is `None` and should always be `Some(prs)`.");
         };
 
         act >= self.quorum()

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1990,7 +1990,9 @@ impl<T: Storage> Raft<T> {
                     act += 1;
                     continue;
                 }
-                if pr.recent_active { act += 1; }
+                if pr.recent_active {
+                    act += 1;
+                }
                 pr.recent_active = false;
             }
             for (&_id, pr) in prs.learners_mut() {

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -3755,6 +3755,22 @@ fn test_add_learner() {
     assert!(n1.prs().learner_ids().contains(&2));
 }
 
+// Ensure when add_voter is called on a peers own ID that it will be promoted.
+// When the action fails, ensure it doesn't mutate the raft state.
+#[test]
+fn test_add_voter_peer_promotes_self_sets_is_learner() {
+    setup_for_test();
+    let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage());
+    // Node is already voter.
+    n1.add_learner(1);
+    assert_eq!(n1.is_learner, false);
+    assert!(n1.prs().voter_ids().contains(&1));
+    n1.remove_node(1);
+    n1.add_learner(1);
+    assert_eq!(n1.is_learner, true);
+    assert!(n1.prs().learner_ids().contains(&1));
+}
+
 // TestRemoveLearner tests that removeNode could update nodes and
 // and removed list correctly.
 #[test]

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -3670,12 +3670,12 @@ fn test_restore_with_learner() {
 
     for &node in s.get_metadata().get_conf_state().get_nodes() {
         assert!(sm.prs().get(node).is_some());
-        assert!(!sm.prs().get(node).unwrap().is_learner);
+        assert!(!sm.prs().learner_ids().contains(&node));
     }
 
     for &node in s.get_metadata().get_conf_state().get_learners() {
         assert!(sm.prs().get(node).is_some());
-        assert!(sm.prs().get(node).unwrap().is_learner);
+        assert!(sm.prs().learner_ids().contains(&node));
     }
 
     assert!(!sm.restore(s));
@@ -3751,8 +3751,8 @@ fn test_add_learner() {
     let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage());
     n1.add_learner(2);
 
-    assert_eq!(n1.prs().learner_ids().iter().next().unwrap(), &2);
-    assert!(n1.prs().get(2).unwrap().is_learner);
+    assert_eq!(*n1.prs().learner_ids().iter().next().unwrap(), 2);
+    assert!(n1.prs().learner_ids().contains(&2));
 }
 
 // TestRemoveLearner tests that removeNode could update nodes and

--- a/tests/test_util/mod.rs
+++ b/tests/test_util/mod.rs
@@ -105,21 +105,13 @@ impl Interface {
                 prs.learner_ids().len(),
             ));
             for id in ids {
+                let progress = Progress::default();
                 if prs.learner_ids().contains(id) {
-                    let progress = Progress {
-                        is_learner: true,
-                        ..Default::default()
-                    };
                     if let Err(e) = self.mut_prs().insert_learner(*id, progress) {
                         panic!("{}", e);
                     }
-                } else {
-                    let progress = Progress {
-                        ..Default::default()
-                    };
-                    if let Err(e) = self.mut_prs().insert_voter(*id, progress) {
-                        panic!("{}", e);
-                    }
+                } else if let Err(e) = self.mut_prs().insert_voter(*id, progress) {
+                    panic!("{}", e);
                 }
             }
             let term = self.term;


### PR DESCRIPTION
Remove the `is_learner` value from `Progress`.

# Rationale

In the process of Joint Consensus (#101) we will have two different `Configuration` sets during some points in operation.

In #108 we made `Progress` a single set (instead of having separate sets for voters and learners). `Progress` still held an `is_learner` value, which meant we had two ways to determine if a node was a learner (via the `ProgressSet.has_learner()` and `Progress.is_learner`). This is not necessary.

We can use `ProgressSet.has_learner(id)` and `ProgressSet.has_voter(id)` exclusively.

# Benefits

Doing this helps minimize complexity, and reduces places we keep track of voter status.

# Future Work

In the future we may be in a joint consensus state, meaning that the `Progress.is_learner` value could be incorrect (If you promoted a learner, then the old configuration still has it has a non-voter).

This internalizes the concept of the `is_learner()` so we can minimize possible bug surface.