### PR TITLE
Change return type of Raft::new() to Result

### DIFF
--- a/benches/suites/raft.rs
+++ b/benches/suites/raft.rs
@@ -11,7 +11,7 @@ fn quick_raft(voters: usize, learners: usize) -> Raft<MemStorage> {
     let id = 1;
     let storage = MemStorage::default();
     let config = Config::new(id);
-    let mut raft = Raft::new(&config, storage);
+    let mut raft = Raft::new(&config, storage).unwrap();
     (0..voters).for_each(|id| {
         raft.add_node(id as u64);
     });

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -220,7 +220,7 @@ impl<T: Storage> Raft<T> {
     /// Creates a new raft for use on the node.
     pub fn new(c: &Config, store: T) -> Result<Raft<T>> {
         c.validate()?;
-        let rs = store.initial_state().expect("");
+        let rs = store.initial_state()?;
         let conf_state = &rs.conf_state;
         let raft_log = RaftLog::new(store, c.tag.clone());
         let mut peers: &[u64] = &c.peers;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -218,8 +218,8 @@ pub fn quorum(total: usize) -> usize {
 
 impl<T: Storage> Raft<T> {
     /// Creates a new raft for use on the node.
-    pub fn new(c: &Config, store: T) -> Raft<T> {
-        c.validate().expect("configuration is invalid");
+    pub fn new(c: &Config, store: T) -> Result<Raft<T>> {
+        c.validate()?;
         let rs = store.initial_state().expect("");
         let conf_state = &rs.conf_state;
         let raft_log = RaftLog::new(store, c.tag.clone());
@@ -303,7 +303,7 @@ impl<T: Storage> Raft<T> {
             r.raft_log.last_index(),
             r.raft_log.last_term()
         );
-        r
+        Ok(r)
     }
 
     /// Grabs an immutable reference to the store.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -190,7 +190,7 @@ impl<T: Storage> RawNode<T> {
     /// Create a new RawNode given some [`Config`](../struct.Config.html) and a list of [`Peer`](raw_node/struct.Peer.html)s.
     pub fn new(config: &Config, store: T, mut peers: Vec<Peer>) -> Result<RawNode<T>> {
         assert_ne!(config.id, 0, "config.id must not be zero");
-        let r = Raft::new(config, store);
+        let r = Raft::new(config, store)?;
         let mut rn = RawNode {
             raft: r,
             prev_hs: Default::default(),

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -4097,5 +4097,8 @@ fn test_prevote_with_check_quorum() {
 fn test_new_raft_with_bad_config_errors() {
     let invalid_config = new_test_config(INVALID_ID, vec![1, 2], 1, 1);
     let raft = Raft::new(&invalid_config, new_storage());
-    assert!(raft.is_err())
+    assert_eq!(
+        raft.err(),
+        Some(Error::ConfigInvalid("invalid node id".to_owned()))
+    )
 }

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -54,48 +54,6 @@ fn new_progress(
     }
 }
 
-<<<<<<< HEAD:tests/integration_cases/test_raft.rs
-=======
-pub fn new_test_config(id: u64, peers: Vec<u64>, election: usize, heartbeat: usize) -> Config {
-    Config {
-        id: id,
-        peers: peers,
-        election_tick: election,
-        heartbeat_tick: heartbeat,
-        max_size_per_msg: NO_LIMIT,
-        max_inflight_msgs: 256,
-        ..Default::default()
-    }
-}
-
-pub fn new_test_raft(
-    id: u64,
-    peers: Vec<u64>,
-    election: usize,
-    heartbeat: usize,
-    storage: MemStorage,
-) -> Interface {
-    Interface::new(Raft::new(&new_test_config(id, peers, election, heartbeat), storage).unwrap())
-}
-
-pub fn new_test_raft_with_prevote(
-    id: u64,
-    peers: Vec<u64>,
-    election: usize,
-    heartbeat: usize,
-    storage: MemStorage,
-    pre_vote: bool,
-) -> Interface {
-    let mut config = new_test_config(id, peers, election, heartbeat);
-    config.pre_vote = pre_vote;
-    new_test_raft_with_config(&config, storage)
-}
-
-pub fn new_test_raft_with_config(config: &Config, storage: MemStorage) -> Interface {
-    Interface::new(Raft::new(config, storage).unwrap())
-}
-
->>>>>>> Change return type of Raft::new() to Result:tests/cases/test_raft.rs
 fn read_messages<T: Storage>(raft: &mut Raft<T>) -> Vec<Message> {
     raft.msgs.drain(..).collect()
 }
@@ -4097,8 +4055,5 @@ fn test_prevote_with_check_quorum() {
 fn test_new_raft_with_bad_config_errors() {
     let invalid_config = new_test_config(INVALID_ID, vec![1, 2], 1, 1);
     let raft = Raft::new(&invalid_config, new_storage());
-    assert_eq!(
-        raft.err(),
-        Some(Error::ConfigInvalid("invalid node id".to_owned()))
-    )
+    assert!(raft.is_err())
 }

--- a/tests/test_util/mod.rs
+++ b/tests/test_util/mod.rs
@@ -145,10 +145,7 @@ pub fn new_test_raft(
     heartbeat: usize,
     storage: MemStorage,
 ) -> Interface {
-    Interface::new(Raft::new(
-        &new_test_config(id, peers, election, heartbeat),
-        storage,
-    ))
+    Interface::new(Raft::new(&new_test_config(id, peers, election, heartbeat), storage).unwrap())
 }
 
 pub fn new_test_raft_with_prevote(
@@ -165,7 +162,7 @@ pub fn new_test_raft_with_prevote(
 }
 
 pub fn new_test_raft_with_config(config: &Config, storage: MemStorage) -> Interface {
-    Interface::new(Raft::new(config, storage))
+    Interface::new(Raft::new(config, storage).unwrap())
 }
 
 pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {


### PR DESCRIPTION
This allows a `ConfigInvalid` error to propogate up and let user handle it.

Fixes #94 
