### PR TITLE
Add bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "continuous-integration/travis-ci/push",
+  "continuous-integration/appveyor/branch"
+]


### PR DESCRIPTION
As I mentioned earlier, we are starting to experiment with [bors](https://app.bors.tech/) to help us manage PRs in TiKV. Since we don't want to jam up TiKV, we can experiment a bit with Raft.

This **should** enable bors. There will still be more configuration and learning before we get it right.

Ultimately you should eventually be able to follow the document in https://bors.tech/documentation/getting-started/ to tell our friend bors they can merge a PR. :)