### PR TITLE
Add Appveyor, bors related branch configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Enable building pull requests.
+    - master
+
 language: rust
 sudo: false
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,12 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Enable building pull requests.
+    - master
+
 environment:
   matrix:
     - TARGET: x86_64-pc-windows-gnu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+environment:
+  matrix:
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: stable
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: nightly
+
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+test_script:
+- cargo test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,4 +29,4 @@ cache:
   - target
 
 test_script:
-- cargo test
+  - cargo test


### PR DESCRIPTION
Adds appveyor so we can test our builds on Windows as well. Since I think none of our maintainers develop on Windows, this can possibly help us find portability bugs.

Also sets up CI to build the branches bors checks things on.