### PR TITLE
Typo fix in node already exists error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,7 +57,7 @@ quick_error! {
         }
         /// The node exists, but should not.
         Exists(id: u64, set: &'static str) {
-            display("The node {} aleady exists in the {} set.", id, set)
+            display("The node {} already exists in the {} set.", id, set)
         }
         /// The node does not exist, but should.
         NotExists(id: u64, set: &'static str) {


### PR DESCRIPTION
Noticed this today while attempting to debug some logs, wanted to contribute it back. Thanks!