### PR TITLE
Update fxhash Hashes to hashbrown Hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = ">0.2"
 protobuf = "2.0.4"
 quick-error = "1.2.2"
 rand = "0.5.4"
-fxhash = "0.2.1"
+hashbrown = "0.1"
 fail = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ For more information, check out an [example](examples/single_mem_node/main.rs#L1
 #[cfg(feature = "failpoint")]
 #[macro_use]
 extern crate fail;
-extern crate fxhash;
+extern crate hashbrown;
 #[macro_use]
 extern crate log;
 extern crate protobuf;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -26,10 +26,11 @@
 // limitations under the License.
 
 use errors::Error;
-use fxhash::{FxBuildHasher, FxHashMap, FxHashSet};
+use hashbrown::{HashMap, HashSet};
+type DefaultHashMapBuilder = ::hashbrown::hash_map::DefaultHashBuilder;
+type DefaultHashSetBuilder = ::hashbrown::hash_map::DefaultHashBuilder;
 use std::cell::RefCell;
 use std::cmp;
-use std::collections::{HashMap, HashSet};
 
 // Since it's an integer, it rounds for us.
 #[inline]
@@ -56,8 +57,8 @@ impl Default for ProgressState {
 
 #[derive(Clone, Debug, Default)]
 struct Configuration {
-    voters: FxHashSet<u64>,
-    learners: FxHashSet<u64>,
+    voters: HashSet<u64>,
+    learners: HashSet<u64>,
 }
 
 /// The status of an election according to a Candidate node.
@@ -77,7 +78,7 @@ pub enum CandidacyStatus {
 /// which could be `Leader`, `Follower` and `Learner`.
 #[derive(Default, Clone)]
 pub struct ProgressSet {
-    progress: FxHashMap<u64, Progress>,
+    progress: HashMap<u64, Progress>,
     configuration: Configuration,
     // A preallocated buffer for sorting in the minimally_commited_index function.
     // You should not depend on these values unless you just set them.
@@ -100,11 +101,11 @@ impl ProgressSet {
         ProgressSet {
             progress: HashMap::with_capacity_and_hasher(
                 voters + learners,
-                FxBuildHasher::default(),
+                DefaultHashMapBuilder::default(),
             ),
             configuration: Configuration {
-                voters: HashSet::with_capacity_and_hasher(voters, FxBuildHasher::default()),
-                learners: HashSet::with_capacity_and_hasher(learners, FxBuildHasher::default()),
+                voters: HashSet::with_capacity_and_hasher(voters, DefaultHashSetBuilder::default()),
+                learners: HashSet::with_capacity_and_hasher(learners, DefaultHashSetBuilder::default()),
             },
             sort_buffer: Default::default(),
         }
@@ -144,13 +145,13 @@ impl ProgressSet {
 
     /// Returns the ids of all known voters.
     #[inline]
-    pub fn voter_ids(&self) -> &FxHashSet<u64> {
+    pub fn voter_ids(&self) -> &HashSet<u64> {
         &self.configuration.voters
     }
 
     /// Returns the ids of all known learners.
     #[inline]
-    pub fn learner_ids(&self) -> &FxHashSet<u64> {
+    pub fn learner_ids(&self) -> &HashSet<u64> {
         &self.configuration.learners
     }
 
@@ -328,7 +329,7 @@ impl ProgressSet {
     }
 
     /// Determine if a quorum is formed from the given set of nodes.
-    pub fn has_quorum(&self, potential_quorum: &FxHashSet<u64>) -> bool {
+    pub fn has_quorum(&self, potential_quorum: &HashSet<u64>) -> bool {
         potential_quorum.len() >= majority(self.voter_ids().len())
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -26,9 +26,8 @@
 // limitations under the License.
 
 use errors::Error;
+use hashbrown::hash_map::DefaultHashBuilder;
 use hashbrown::{HashMap, HashSet};
-type DefaultHashMapBuilder = ::hashbrown::hash_map::DefaultHashBuilder;
-type DefaultHashSetBuilder = ::hashbrown::hash_map::DefaultHashBuilder;
 use std::cell::RefCell;
 use std::cmp;
 
@@ -101,13 +100,13 @@ impl ProgressSet {
         ProgressSet {
             progress: HashMap::with_capacity_and_hasher(
                 voters + learners,
-                DefaultHashMapBuilder::default(),
+                DefaultHashBuilder::default(),
             ),
             configuration: Configuration {
-                voters: HashSet::with_capacity_and_hasher(voters, DefaultHashSetBuilder::default()),
+                voters: HashSet::with_capacity_and_hasher(voters, DefaultHashBuilder::default()),
                 learners: HashSet::with_capacity_and_hasher(
                     learners,
-                    DefaultHashSetBuilder::default(),
+                    DefaultHashBuilder::default(),
                 ),
             },
             sort_buffer: Default::default(),

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -105,7 +105,10 @@ impl ProgressSet {
             ),
             configuration: Configuration {
                 voters: HashSet::with_capacity_and_hasher(voters, DefaultHashSetBuilder::default()),
-                learners: HashSet::with_capacity_and_hasher(learners, DefaultHashSetBuilder::default()),
+                learners: HashSet::with_capacity_and_hasher(
+                    learners,
+                    DefaultHashSetBuilder::default(),
+                ),
             },
             sort_buffer: Default::default(),
         }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -28,7 +28,7 @@
 use std::cmp;
 
 use eraftpb::{Entry, EntryType, HardState, Message, MessageType, Snapshot};
-use fxhash::{FxHashMap, FxHashSet};
+use hashbrown::{HashMap, HashSet};
 use protobuf::RepeatedField;
 use rand::{self, Rng};
 
@@ -121,7 +121,7 @@ pub struct Raft<T: Storage> {
     /// The current votes for this node in an election.
     ///
     /// Reset when changing role.
-    pub votes: FxHashMap<u64, bool>,
+    pub votes: HashMap<u64, bool>,
 
     /// The list of messages.
     pub msgs: Vec<Message>,
@@ -719,7 +719,7 @@ impl<T: Storage> Raft<T> {
         // but doesn't change anything else. In particular it does not increase
         // self.term or change self.vote.
         self.state = StateRole::PreCandidate;
-        self.votes = FxHashMap::default();
+        self.votes = HashMap::default();
         // If a network partition happens, and leader is in minority partition,
         // it will step down, and become follower without notifying others.
         self.leader_id = INVALID_ID;
@@ -1392,7 +1392,7 @@ impl<T: Storage> Raft<T> {
                     return Ok(());
                 }
 
-                let mut self_set = FxHashSet::default();
+                let mut self_set = HashSet::default();
                 self_set.insert(self.id);
                 if !self.prs().has_quorum(&self_set) {
                     // thinking: use an interally defined context instead of the user given context.

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,7 +26,7 @@
 // limitations under the License.
 
 use eraftpb::HardState;
-use fxhash::FxHashMap;
+use hashbrown::HashMap;
 
 use progress::Progress;
 use raft::{Raft, SoftState, StateRole};
@@ -44,9 +44,9 @@ pub struct Status {
     /// The index of the last entry to have been applied.
     pub applied: u64,
     /// The progress towards catching up and applying logs.
-    pub progress: FxHashMap<u64, Progress>,
+    pub progress: HashMap<u64, Progress>,
     /// The progress of learners in catching up and applying logs.
-    pub learner_progress: FxHashMap<u64, Progress>,
+    pub learner_progress: HashMap<u64, Progress>,
 }
 
 impl Status {

--- a/tests/integration_cases/test_raft.rs
+++ b/tests/integration_cases/test_raft.rs
@@ -29,7 +29,7 @@ use std::cmp;
 use std::collections::HashMap;
 use std::panic::{self, AssertUnwindSafe};
 
-use fxhash::FxHashSet;
+use hashbrown::HashSet;
 use protobuf::{self, RepeatedField};
 use raft::eraftpb::{
     ConfChange, ConfChangeType, ConfState, Entry, EntryType, HardState, Message, MessageType,
@@ -2746,7 +2746,7 @@ fn test_restore() {
             .get_nodes()
             .iter()
             .cloned()
-            .collect::<FxHashSet<_>>(),
+            .collect::<HashSet<_>>(),
     );
     assert!(!sm.restore(s));
 }
@@ -2956,7 +2956,7 @@ fn test_add_node() {
     r.add_node(2);
     assert_eq!(
         r.prs().voter_ids(),
-        &vec![1, 2].into_iter().collect::<FxHashSet<_>>()
+        &vec![1, 2].into_iter().collect::<HashSet<_>>()
     );
 }
 
@@ -3032,7 +3032,7 @@ fn test_raft_nodes() {
     for (i, (ids, wids)) in tests.drain(..).enumerate() {
         let r = new_test_raft(1, ids, 10, 1, new_storage());
         let voter_ids = r.prs().voter_ids();
-        let wids = wids.into_iter().collect::<FxHashSet<_>>();
+        let wids = wids.into_iter().collect::<HashSet<_>>();
         if voter_ids != &wids {
             panic!("#{}: nodes = {:?}, want {:?}", i, voter_ids, wids);
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -25,7 +25,7 @@ extern crate rand;
 extern crate lazy_static;
 #[cfg(feature = "failpoint")]
 extern crate fail;
-extern crate fxhash;
+extern crate hashbrown;
 
 /// Get the count of macro's arguments.
 ///


### PR DESCRIPTION
Hey!

I was looking for small improvements I could do to improve this project and I was thinking about using the "new" SwissTable hashes from Google. [`hashbrown`](https://github.com/Amanieu/hashbrown) is a crate that implements them and it says it is around [2 times faster](https://github.com/Amanieu/hashbrown#features) than `fxhash`. 

This PR is updating all `HashMap` and `HashSet` of `fxhash` to use the more performante `HashMap` and `HashSet` from `hashbrown`.

Even if `hashbrown` is a drop-in replacement for the standard hashes, this PR changes only the hashes of `fxhash`, just to make the changes more atomic.

Feel free to change this PR if you want!

Thank you guys for this great crate 😃 