### PR TITLE
Update clippy lints.

### DIFF
--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -196,7 +196,8 @@ fn send_propose(sender: mpsc::Sender<Msg>) {
                 cb: Box::new(move || {
                     s1.send(0).unwrap();
                 }),
-            }).unwrap();
+            })
+            .unwrap();
 
         let n = r1.recv().unwrap();
         assert_eq!(n, 0);

--- a/src/eraftpb.rs
+++ b/src/eraftpb.rs
@@ -3,7 +3,7 @@
 
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,7 +67,7 @@ quick_error! {
 }
 
 impl cmp::PartialEq for Error {
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
     fn eq(&self, other: &Error) -> bool {
         match (self, other) {
             (&Error::StepPeerNotFound, &Error::StepPeerNotFound) => true,
@@ -112,7 +112,7 @@ quick_error! {
 }
 
 impl cmp::PartialEq for StorageError {
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
     fn eq(&self, other: &StorageError) -> bool {
         match (self, other) {
             (&StorageError::Compacted, &StorageError::Compacted) => true,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -235,18 +235,16 @@ impl ProgressSet {
 
     #[inline(always)]
     fn assert_progress_and_configuration_consistent(&self) {
-        debug_assert!(
-            self.configuration
-                .voters
-                .union(&self.configuration.learners)
-                .all(|v| self.progress.contains_key(v))
-        );
-        debug_assert!(
-            self.progress
-                .keys()
-                .all(|v| self.configuration.learners.contains(v)
-                    || self.configuration.voters.contains(v))
-        );
+        debug_assert!(self
+            .configuration
+            .voters
+            .union(&self.configuration.learners)
+            .all(|v| self.progress.contains_key(v)));
+        debug_assert!(self
+            .progress
+            .keys()
+            .all(|v| self.configuration.learners.contains(v)
+                || self.configuration.voters.contains(v)));
         assert_eq!(
             self.configuration.voters.len() + self.configuration.learners.len(),
             self.progress.len()

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -204,6 +204,7 @@ pub fn vote_resp_msg_type(t: MessageType) -> MessageType {
 }
 
 impl<T: Storage> Raft<T> {
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::new_ret_no_self))]
     /// Creates a new raft for use on the node.
     pub fn new(c: &Config, store: T) -> Result<Raft<T>> {
         c.validate()?;
@@ -555,7 +556,7 @@ impl<T: Storage> Raft<T> {
         self.bcast_heartbeat_with_ctx(ctx)
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
     fn bcast_heartbeat_with_ctx(&mut self, ctx: Option<Vec<u8>>) {
         let self_id = self.id;
         let mut prs = self.take_prs();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -138,7 +138,8 @@ impl Ready {
             (match since_idx {
                 None => raft.raft_log.next_entries(),
                 Some(idx) => raft.raft_log.next_entries_since(idx),
-            }).unwrap_or_else(Vec::new),
+            })
+            .unwrap_or_else(Vec::new),
         );
         let ss = raft.soft_state();
         if &ss != prev_ss {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -217,6 +217,7 @@ pub struct RawNode<T: Storage> {
 }
 
 impl<T: Storage> RawNode<T> {
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::new_ret_no_self))]
     /// Create a new RawNode given some [`Config`](../struct.Config.html) and a list of [`Peer`](raw_node/struct.Peer.html)s.
     pub fn new(config: &Config, store: T, mut peers: Vec<Peer>) -> Result<RawNode<T>> {
         assert_ne!(config.id, 0, "config.id must not be zero");
@@ -316,7 +317,7 @@ impl<T: Storage> RawNode<T> {
     }
 
     /// ProposeConfChange proposes a config change.
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
     pub fn propose_conf_change(&mut self, context: Vec<u8>, cc: ConfChange) -> Result<()> {
         let data = protobuf::Message::write_to_bytes(&cc)?;
         let mut m = Message::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,7 +64,8 @@ pub fn limit_size<T: Message + Clone>(entries: &mut Vec<T>, max: u64) {
                 size += u64::from(Message::compute_size(e));
                 size <= max
             }
-        }).count();
+        })
+        .count();
 
     entries.truncate(limit);
 }

--- a/tests/integration_cases/test_raw_node.rs
+++ b/tests/integration_cases/test_raw_node.rs
@@ -86,7 +86,8 @@ fn new_raw_node(
         &new_test_config(id, peers, election, heartbeat),
         storage,
         peer_nodes,
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 // test_raw_node_step ensures that RawNode.Step ignore local message.
@@ -102,7 +103,8 @@ fn test_raw_node_step() {
             MessageType::MsgHup,
             MessageType::MsgUnreachable,
             MessageType::MsgSnapStatus,
-        ].contains(msg_t)
+        ]
+        .contains(msg_t)
         {
             assert_eq!(res, Err(Error::StepLocalMsg));
         }

--- a/tests/test_util/mod.rs
+++ b/tests/test_util/mod.rs
@@ -299,10 +299,12 @@ impl Network {
                     .get(&Connem {
                         from: m.get_from(),
                         to: m.get_to(),
-                    }).cloned()
+                    })
+                    .cloned()
                     .unwrap_or(0f64);
                 rand::random::<f64>() >= perc
-            }).collect()
+            })
+            .collect()
     }
 
     pub fn send(&mut self, msgs: Vec<Message>) {


### PR DESCRIPTION
Some clippy lints / rustfmt are now not working after update.

This fixes them.

Affected: 

* #161
* #159 
* #160 
* #162