### PR TITLE
fix a test case about power cycle.

### DIFF
--- a/benches/suites/progress_set.rs
+++ b/benches/suites/progress_set.rs
@@ -153,7 +153,10 @@ pub fn bench_progress_set_voters(c: &mut Criterion) {
             let set = quick_progress_set(voters, learners);
             b.iter(|| {
                 let set = set.clone();
-                let sum = set.voters().fold(0, |mut sum, _| { sum += 1; sum });
+                let sum = set.voters().fold(0, |mut sum, _| {
+                    sum += 1;
+                    sum
+                });
                 sum
             });
         }
@@ -173,7 +176,10 @@ pub fn bench_progress_set_learners(c: &mut Criterion) {
             let set = quick_progress_set(voters, learners);
             b.iter(|| {
                 let set = set.clone();
-                let sum = set.voters().fold(0, |mut sum, _| { sum += 1; sum });
+                let sum = set.voters().fold(0, |mut sum, _| {
+                    sum += 1;
+                    sum
+                });
                 sum
             });
         }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -304,14 +304,14 @@ impl<T: Storage> Raft<T> {
         }
         let term = r.term;
         r.become_follower(term, INVALID_ID);
-        
+
         // Used to resume Joint Consensus Changes
         let pending_conf_state = raft_state.pending_conf_state();
         let pending_conf_state_start_index = raft_state.pending_conf_state_start_index();
         match (pending_conf_state, pending_conf_state_start_index) {
             (Some(state), Some(idx)) => {
                 r.begin_membership_change(&ConfChange::from((idx.clone(), state.clone())))?;
-            },
+            }
             (None, None) => (),
             _ => unreachable!("Should never find pending_conf_change without an index."),
         };

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -297,7 +297,11 @@ impl<T: Storage> RaftLog<T> {
 
     /// Appends a set of entries to the unstable list.
     pub fn append(&mut self, ents: &[Entry]) -> u64 {
-        trace!("{} Entries being appended to unstable list: {:?}", self.tag, ents);
+        trace!(
+            "{} Entries being appended to unstable list: {:?}",
+            self.tag,
+            ents
+        );
         if ents.is_empty() {
             return self.last_index();
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,7 @@
 
 use std::u64;
 
-use eraftpb::{ConfState, ConfChange, ConfChangeType};
+use eraftpb::{ConfChange, ConfChangeType, ConfState};
 use protobuf::Message;
 
 /// A number to represent that there is no limit.


### PR DESCRIPTION
Without the PR, test case `leader_power_cycles_no_compaction` fails because `conf state` is not persisted before power cycle. We need to do this explicitly.

The PR also contains some code format generated by `cargo fmt`. I have checked the cargo version, seems my toolchain is correct. Seems you forget to format code? If so, let's keep those changes.