### PR TITLE
remove unnecessary clippy allow new_ret_no_self

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -204,7 +204,6 @@ pub fn vote_resp_msg_type(t: MessageType) -> MessageType {
 }
 
 impl<T: Storage> Raft<T> {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::new_ret_no_self))]
     /// Creates a new raft for use on the node.
     pub fn new(c: &Config, store: T) -> Result<Raft<T>> {
         c.validate()?;

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -218,7 +218,6 @@ pub struct RawNode<T: Storage> {
 }
 
 impl<T: Storage> RawNode<T> {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::new_ret_no_self))]
     /// Create a new RawNode given some [`Config`](../struct.Config.html) and a list of [`Peer`](raw_node/struct.Peer.html)s.
     pub fn new(config: &Config, store: T, mut peers: Vec<Peer>) -> Result<RawNode<T>> {
         assert_ne!(config.id, 0, "config.id must not be zero");


### PR DESCRIPTION
As of rust-lang/rust-clippy#3253 clippy allows returning Result<T> when creating a `new` function for T, so these explicit allows are not needed. 