### PR TITLE
Rust 2018 for harness

### DIFF
--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/pingcap/raft-rs/harness"
 description = "A testing harness for Raft."
 categories = []
+edition = "2018"
 
 # Make sure to synchronize updates with Raft.
 [dependencies]

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -33,10 +33,6 @@ This module contains various testing harness utilities for Raft.
 
 */
 
-extern crate env_logger;
-extern crate raft;
-extern crate rand;
-
 mod interface;
 mod network;
 


### PR DESCRIPTION
Signed-off-by: ice1000 <ice1000kotlin@foxmail.com>

Update the harness subcrate to rust 2018, removed some `extern crate`s