### PR TITLE
example: add tag for dynamically initialized raft instance

### DIFF
--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -169,6 +169,7 @@ impl Node {
         }
         let mut cfg = example_config();
         cfg.id = msg.get_to();
+        cfg.tag = format!("peer_{}", msg.get_to());
         let storage = MemStorage::new();
         self.raft_group = Some(RawNode::new(&cfg, storage).unwrap());
     }


### PR DESCRIPTION
Add a simple tag `peer_{id}` for dynamically initialized raft instance and now the logs are more clear : 
```
 INFO 2019-04-09T02:54:25Z: raft::raft: peer_1 became leader at term 1
 INFO 2019-04-09T02:54:25Z: raft::raft: peer_2 became follower at term 0
 INFO 2019-04-09T02:54:25Z: raft::raft: peer_2 newRaft [peers: [], term: 0, commit: 1, applied: 1, last_index: 1, last_term: 0, pending_membership_change: None]
 INFO 2019-04-09T02:54:25Z: raft::raft: peer_2 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
 INFO 2019-04-09T02:54:25Z: raft::raft: peer_2 became follower at term 1
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_3 became follower at term 0
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_3 newRaft [peers: [], term: 0, commit: 1, applied: 1, last_index: 1, last_term: 0, pending_membership_change: None]
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_4 became follower at term 0
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_3 became follower at term 1
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_4 newRaft [peers: [], term: 0, commit: 1, applied: 1, last_index: 1, last_term: 0, pending_membership_change: None]
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_4 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
 INFO 2019-04-09T02:54:26Z: raft::raft: peer_4 became follower at term 1
 INFO 2019-04-09T02:54:27Z: raft::raft: peer_5 became follower at term 0
 INFO 2019-04-09T02:54:27Z: raft::raft: peer_5 newRaft [peers: [], term: 0, commit: 1, applied: 1, last_index: 1, last_term: 0, pending_membership_change: None]
 INFO 2019-04-09T02:54:27Z: raft::raft: peer_5 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
 INFO 2019-04-09T02:54:27Z: raft::raft: peer_5 became follower at term 1

```