### PR TITLE
fix a bug about snapshot and adjust some test cases

### DIFF
--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -25,7 +25,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use raft::{eraftpb::Message, storage::MemStorage, Progress, ProgressSet, Raft, Result};
+use raft::{eraftpb::Message, storage::MemStorage, Raft, Result};
 use std::ops::{Deref, DerefMut};
 
 /// A simulated Raft façade for testing.
@@ -61,30 +61,6 @@ impl Interface {
         match self.raft {
             Some(_) => self.msgs.drain(..).collect(),
             None => vec![],
-        }
-    }
-
-    /// Initialize a raft with the given ID and peer set.
-    pub fn initial(&mut self, id: u64, ids: &[u64]) {
-        if self.raft.is_some() {
-            self.id = id;
-            let prs = self.take_prs();
-            self.set_prs(ProgressSet::with_capacity(
-                ids.len(),
-                prs.learner_ids().len(),
-            ));
-            for id in ids {
-                let progress = Progress::new(0, 256);
-                if prs.learner_ids().contains(id) {
-                    if let Err(e) = self.mut_prs().insert_learner(*id, progress) {
-                        panic!("{}", e);
-                    }
-                } else if let Err(e) = self.mut_prs().insert_voter(*id, progress) {
-                    panic!("{}", e);
-                }
-            }
-            let term = self.term;
-            self.reset(term);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ use super::{
 };
 
 /// Config contains the parameters to start a raft.
+#[derive(Clone)]
 pub struct Config {
     /// The identity of the local raft. It cannot be 0, and must be unique in the group.
     pub id: u64,

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2040,7 +2040,10 @@ impl<T: Storage> Raft<T> {
 
         let next_idx = self.raft_log.last_index() + 1;
         let mut prs = ProgressSet::restore_snapmeta(meta, next_idx, self.max_inflight);
-        prs.get_mut(self.id).unwrap().matched = next_idx - 1;
+        if let Some(pr) = prs.get_mut(self.id) {
+            // The snapshot could be too old so that it doesn't contain the peer.
+            pr.matched = next_idx - 1;
+        }
         if self.is_learner && prs.configuration().voters().contains(&self.id) {
             self.is_learner = false;
         }

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -199,7 +199,12 @@ impl<T: Storage> RaftLog<T> {
 
     /// Answers the question: Does this index belong to this term?
     pub fn match_term(&self, idx: u64, term: u64) -> bool {
-        self.term(idx).map(|t| t == term).unwrap_or(false)
+        match self.term(idx) {
+            // For uninitialized storage, should return false.
+            Ok(0) => term == 0 && self.last_index() > 0,
+            Ok(t) => t == term,
+            _ => false,
+        }
     }
 
     /// Returns None if the entries cannot be appended. Otherwise,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -155,6 +155,11 @@ impl MemStorageCore {
         &self.raft_state.hard_state
     }
 
+    /// Get the mut hard state.
+    pub fn mut_hard_state(&mut self) -> &mut HardState {
+        &mut self.raft_state.hard_state
+    }
+
     /// Commit to an index.
     ///
     /// # Panics


### PR DESCRIPTION
The bug causes an exmaple panics in #205 .

In our implemetation, `RaftLog::term(un_received_index)` returns `0`. So if a peer receives a snapshot or normal entry with log-term `0`, `RaftLog::match_term(log_term, un_received_index)` will return `true` but it should be `false` exactly.

This PR fixes it by making `RaftLog::match_term` cover this case.

And, add a case `test_snapshot_with_term_0` to cover it, and do some adjusts for some other test cases. At last, remove `Interface::initial` because we don't need it any more.