### PR TITLE
*: tiny refactor

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -651,7 +651,9 @@ impl<T: Storage> Raft<T> {
         self.set_prs(prs);
     }
 
-    /// Broadcasts heartbeats to all the followers if it's leader.
+    /// Broadcast heartbeats to all the followers.
+    ///
+    /// If it's not leader, nothing will happen.
     pub fn ping(&mut self) {
         if self.state == StateRole::Leader {
             self.bcast_heartbeat();

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -651,6 +651,13 @@ impl<T: Storage> Raft<T> {
         self.set_prs(prs);
     }
 
+    /// Broadcasts heartbeats to all the followers if it's leader.
+    pub fn ping(&mut self) {
+        if self.state == StateRole::Leader {
+            self.bcast_heartbeat();
+        }
+    }
+
     /// Sends RPC, without entries to all the peers.
     pub fn bcast_heartbeat(&mut self) {
         let ctx = self.read_only.last_pending_request_ctx();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -285,6 +285,13 @@ impl<T: Storage> RawNode<T> {
         self.raft.step(m)
     }
 
+    /// Broadcast heartbeats to all the followers.
+    ///
+    /// If it's not leader, nothing will happen.
+    pub fn ping(&mut self) {
+        self.raft.ping()
+    }
+
     /// ProposeConfChange proposes a config change.
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
     pub fn propose_conf_change(&mut self, context: Vec<u8>, cc: ConfChange) -> Result<()> {

--- a/src/status.rs
+++ b/src/status.rs
@@ -27,9 +27,9 @@
 
 use crate::eraftpb::HardState;
 
-use crate::ProgressSet;
 use crate::raft::{Raft, SoftState, StateRole};
 use crate::storage::Storage;
+use crate::ProgressSet;
 
 /// Represents the current status of the raft
 #[derive(Default)]

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,15 +26,14 @@
 // limitations under the License.
 
 use crate::eraftpb::HardState;
-use hashbrown::HashMap;
 
-use crate::progress::Progress;
+use crate::ProgressSet;
 use crate::raft::{Raft, SoftState, StateRole};
 use crate::storage::Storage;
 
 /// Represents the current status of the raft
 #[derive(Default)]
-pub struct Status {
+pub struct Status<'a> {
     /// The ID of the current node.
     pub id: u64,
     /// The hardstate of the raft, representing voted state.
@@ -44,14 +43,12 @@ pub struct Status {
     /// The index of the last entry to have been applied.
     pub applied: u64,
     /// The progress towards catching up and applying logs.
-    pub progress: HashMap<u64, Progress>,
-    /// The progress of learners in catching up and applying logs.
-    pub learner_progress: HashMap<u64, Progress>,
+    pub progress: Option<&'a ProgressSet>,
 }
 
-impl Status {
+impl<'a> Status<'a> {
     /// Gets a copy of the current raft status.
-    pub fn new<T: Storage>(raft: &Raft<T>) -> Status {
+    pub fn new<T: Storage>(raft: &'a Raft<T>) -> Status<'a> {
         let mut s = Status {
             id: raft.id,
             ..Default::default()
@@ -60,12 +57,7 @@ impl Status {
         s.ss = raft.soft_state();
         s.applied = raft.raft_log.get_applied();
         if s.ss.raft_state == StateRole::Leader {
-            s.progress = raft.prs().voters().map(|(&k, v)| (k, v.clone())).collect();
-            s.learner_progress = raft
-                .prs()
-                .learners()
-                .map(|(&k, v)| (k, v.clone()))
-                .collect();
+            s.progress = Some(raft.prs());
         }
         s
     }


### PR DESCRIPTION
Make status borrow data instead of cloning. Also introduce a new API to
force leader broadcast heartbeats.