### PR TITLE
Don't cache all of the cargo caches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ env:
     - RUST_BACKTRACE=1
     - RUSTFLAGS="-D warnings"
 
+# Inspired by https://levans.fr/rust_travis_cache.html
+cache:
+  directories:
+    - /home/travis/.cargo
+# But don't cache the cargo registry
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
+
+
 install:
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add rustfmt; fi
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add clippy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   global:
     - RUST_BACKTRACE=1
     - RUSTFLAGS="-D warnings"
-cache: cargo
 
 install:
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add rustfmt; fi


### PR DESCRIPTION
We've been seeing a lot of failed builds for Windows Nightly and they *seem* to be cache related. My *hope* is this can resolve it without resorting to drastic measures like disabling windows nightly.

I read https://levans.fr/rust_travis_cache.html and decided to have a try at doing that.

You can compare https://travis-ci.org/pingcap/raft-rs/builds/529513440 with https://travis-ci.org/pingcap/raft-rs/builds/528351058 the build times don't vary that much.