### PR TITLE
Ease protobuf dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ failpoint = ["fail"]
 # Make sure to synchronize updates with Harness.
 [dependencies]
 log = ">0.2"
-protobuf = "~2.1-2.2"
+protobuf = "2"
 lazy_static = "1.3.0"
 prost = "0.5"
 prost-derive = "0.5"


### PR DESCRIPTION
I realized when trying to use Raft 0.5.0 in kvproto/tikv that the protobuf dependecy in Raft is wayyy too strict.