### PR TITLE
Move regenerate docs to subcrate as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,7 @@ cargo watch -s "cargo check"
 
 ### Modifying Protobufs
 
-If proto file `eraftpb.proto` changed, run the command to regenerate `eraftpb.rs`:
-
-```bash
-cargo build --features gen
-```
-
-or using Cargo watch:
-
-```bash
-cargo watch -s "cargo check --features gen"
-```
+See [instructions](proto/README.md) in the proto subdirectory.
 
 ### Benchmarks
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,22 @@
+# Raft Proto
+
+[![Documentation](https://docs.rs/raft-proto/badge.svg)](https://docs.rs/raft-proto/)
+[![Crates.io](https://img.shields.io/crates/v/raft-proto.svg)](https://crates.io/crates/raft-proto)
+
+This crate contains the protobuf structs used by raft.
+
+## Regenerate Protobufs
+
+If the protobuf file `eraftpb.proto` changed,
+run this command to regenerate `eraftpb.rs`:
+
+```bash
+cargo build --features gen
+```
+
+or using Cargo watch:
+
+```bash
+cargo watch -s "cargo check --features gen"
+```
+


### PR DESCRIPTION
Signed-off-by: ice1000 <ice1000kotlin@foxmail.com>

As title, because the regeneration should now be done by running the command in the subcrate (instead of the raft crate).
Added docs.rs and crates.io badges for the subcrate by the way.