### PR TITLE
Bump minimum supported rust version from 1.31 to 1.32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ os:
 rust:
   - stable
   - nightly
-  # First Rust 2018 Stable. Officially the oldest compiler we support.
-  - 1.31.0
+  # Officially the oldest compiler we support.
+  - 1.32.0
 env:
   global:
     - RUST_BACKTRACE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
   - stable
   - nightly
   # Officially the oldest compiler we support.
-  - 1.32.0
+  - 1.33.0
 env:
   global:
     - RUST_BACKTRACE=1

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A complete Raft model contains 4 essential parts:
 ## Developing the Raft crate
 
 `Raft` is built using the latest version of `stable` Rust, using [the 2018 edition](https://doc.rust-lang.org/edition-guide/rust-2018/).
+Minimum supported version is `1.33.0`.
 
 Using `rustup` you can get started this way:
 


### PR DESCRIPTION
Signed-off-by: ice1000 <ice1000kotlin@foxmail.com>

As title. According to https://github.com/pingcap/raft-rs/pull/250#issuecomment-507464872