### PR TITLE
Use Git dep for Prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ failpoint = ["fail"]
 [dependencies]
 log = ">0.2"
 lazy_static = "1.3.0"
-prost = "0.5"
-prost-derive = "0.5"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
+prost-derive = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 bytes = "0.4.11"
 quick-error = "1.2.2"
 rand = "0.5.4"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raft-proto"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["The TiKV Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,5 +22,5 @@ protobuf-build = "0.6"
 [dependencies]
 bytes = "0.4.11"
 lazy_static = "1.3.0"
-prost = "0.5"
-prost-derive = "0.5"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
+prost-derive = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }


### PR DESCRIPTION
Use a Git dep for Prost so we get some optimisations which are not present in the current release.

PTAL @ice1000 @Hoverbear 