### PR TITLE
progress: make majority function public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ pub use self::config::Config;
 pub use self::errors::{Error, Result, StorageError};
 pub use self::log_unstable::Unstable;
 pub use self::progress::inflights::Inflights;
-pub use self::progress::progress_set::{Configuration, ProgressSet};
+pub use self::progress::progress_set::{Configuration, ProgressSet, majority};
 pub use self::progress::{Progress, ProgressState};
 pub use self::raft::{vote_resp_msg_type, Raft, SoftState, StateRole, INVALID_ID, INVALID_INDEX};
 pub use self::raft_log::{RaftLog, NO_LIMIT};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ pub use self::config::Config;
 pub use self::errors::{Error, Result, StorageError};
 pub use self::log_unstable::Unstable;
 pub use self::progress::inflights::Inflights;
-pub use self::progress::progress_set::{Configuration, ProgressSet, majority};
+pub use self::progress::progress_set::{majority, Configuration, ProgressSet};
 pub use self::progress::{Progress, ProgressState};
 pub use self::raft::{vote_resp_msg_type, Raft, SoftState, StateRole, INVALID_ID, INVALID_INDEX};
 pub use self::raft_log::{RaftLog, NO_LIMIT};

--- a/src/progress/progress_set.rs
+++ b/src/progress/progress_set.rs
@@ -34,9 +34,9 @@ use hashbrown::{HashMap, HashSet};
 use slog::Logger;
 use std::cell::RefCell;
 
-// Since it's an integer, it rounds for us.
+/// Get the majority number of given nodes count.
 #[inline]
-fn majority(total: usize) -> usize {
+pub fn majority(total: usize) -> usize {
     (total / 2) + 1
 }
 


### PR DESCRIPTION
Majority should be defined by raft and client may need to know what is
it to do some prediction and optimizations.