### PR TITLE
update protobuf-build and bump to 0.6.0-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 sudo: false
 
 language: rust
-os:
-  - linux
-  - windows
-  - osx
+os: linux
 rust:
   - stable
   - nightly
   # Officially the oldest compiler we support.
   - 1.33.0
+matrix:
+  include:
+  - os: windows
+    rust: stable
+  - os: osx
+    rust: stable
 env:
   global:
     - RUST_BACKTRACE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.6.0-alpha - 2019-07-24
 
-- Protos now is a separate crate ()
+- Protos now is a separate crate (https://github.com/pingcap/raft-rs/pull/247)
 - raft-rs is rust-2018 compatible (https://github.com/pingcap/raft-rs/pull/184)
 - Optional support for batch MsgAppend (https://github.com/pingcap/raft-rs/pull/179)
 - Harden follower read (https://github.com/pingcap/raft-rs/pull/220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.6.0-alpha - 2019-07-24
+
+- Protos now is a separate crate ()
+- raft-rs is rust-2018 compatible (https://github.com/pingcap/raft-rs/pull/184)
+- Optional support for batch MsgAppend (https://github.com/pingcap/raft-rs/pull/179)
+- Harden follower read (https://github.com/pingcap/raft-rs/pull/220)
+- Migrate to slog (https://github.com/pingcap/raft-rs/pull/185)
+- Several code refactor and API clean up
+- Optional support for prost
+
 # 0.5.0 - 2019-02-11
 
 - Introduced an experimental Joint Consensus based arbitrary membership change feature. (https://github.com/pingcap/raft-rs/pull/101)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raft"
-version = "0.5.0"
+version = "0.6.0-alpha"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]
@@ -28,7 +28,7 @@ log = ">0.2"
 protobuf = "2"
 slog = "2.2"
 quick-error = "1.2.2"
-raft-proto = { path = "proto", default-features = false }
+raft-proto = { path = "proto", version = "0.6.0-alpha", default-features = false }
 rand = "0.7.0"
 hashbrown = "0.5"
 fail = { version = "0.3", optional = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raft-proto"
-version = "0.1.0"
+version = "0.6.0-alpha"
 authors = ["The TiKV Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ protobuf-codec = ["protobuf-build/protobuf-codec"]
 prost-codec = ["prost", "prost-derive", "bytes", "lazy_static", "protobuf-build/prost-codec"]
 
 [build-dependencies]
-protobuf-build = { git = "https://github.com/tikv/protobuf-build.git", rev = "54c089895e4bf42481c2af46ebf73295c0e5d6b9", default-features = false }
+protobuf-build = { version = "0.8", default-features = false }
 
 [dependencies]
 bytes = { version = "0.4.11", optional = true }


### PR DESCRIPTION
Now that protobuf-build is released, raft-rs can be released too.