### PR TITLE
support to specify a logger when creating RawNode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ prost-codec = ["raft-proto/prost-codec"]
 log = ">0.2"
 protobuf = "2"
 slog = "2.2"
+slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "91904ade" }
 quick-error = "1.2.2"
 raft-proto = { path = "proto", version = "0.6.0-alpha", default-features = false }
 rand = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ prost-codec = ["raft-proto/prost-codec"]
 log = ">0.2"
 protobuf = "2"
 slog = "2.2"
-slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "91904ade" }
 quick-error = "1.2.2"
 raft-proto = { path = "proto", version = "0.6.0-alpha", default-features = false }
 rand = "0.7.0"

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -77,7 +77,7 @@ fn main() {
     };
 
     // Create the Raft node.
-    let mut r = RawNode::new(&cfg, storage).unwrap().with_logger(&logger);
+    let mut r = RawNode::new_with_logger(&cfg, storage, &logger).unwrap();
 
     let (sender, receiver) = mpsc::channel();
 

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -77,7 +77,7 @@ fn main() {
     };
 
     // Create the Raft node.
-    let mut r = RawNode::new_with_logger(&cfg, storage, &logger).unwrap();
+    let mut r = RawNode::with_logger(&cfg, storage, &logger).unwrap();
 
     let (sender, receiver) = mpsc::channel();
 

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -103,7 +103,7 @@ impl Network {
                     let mut config = config.clone();
                     config.id = *id;
                     config.tag = id.to_string();
-                    let r = Raft::new_with_logger(&config, store, l).unwrap().into();
+                    let r = Raft::with_logger(&config, store, l).unwrap().into();
                     npeers.insert(*id, r);
                 }
                 Some(r) => {

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -103,7 +103,7 @@ impl Network {
                     let mut config = config.clone();
                     config.id = *id;
                     config.tag = id.to_string();
-                    let r = Raft::new(&config, store).unwrap().with_logger(l).into();
+                    let r = Raft::new_with_logger(&config, store, l).unwrap().into();
                     npeers.insert(*id, r);
                 }
                 Some(r) => {

--- a/harness/tests/integration_cases/test_membership_changes.rs
+++ b/harness/tests/integration_cases/test_membership_changes.rs
@@ -39,7 +39,7 @@ mod api {
     #[test]
     fn can_transition() -> Result<()> {
         let l = testing_logger().new(o!("test" => "can_transition"));
-        let mut raft = Raft::new_with_logger(
+        let mut raft = Raft::with_logger(
             &Config {
                 id: 1,
                 tag: "1".into(),
@@ -59,7 +59,7 @@ mod api {
     #[test]
     fn checks_for_overlapping_membership() -> Result<()> {
         let l = testing_logger().new(o!("test" => "checks_for_overlapping_membership"));
-        let mut raft = Raft::new_with_logger(
+        let mut raft = Raft::with_logger(
             &Config {
                 id: 1,
                 tag: "1".into(),
@@ -84,7 +84,7 @@ mod api {
             ..Default::default()
         };
         let store = MemStorage::new_with_conf_state((vec![1, 2, 3], vec![4]));
-        let mut raft = Raft::new_with_logger(&config, store, &l)?;
+        let mut raft = Raft::with_logger(&config, store, &l)?;
         let begin_conf_change = begin_conf_change(&[1, 2], &[3, 4], raft.raft_log.last_index() + 1);
         assert!(raft.begin_membership_change(&begin_conf_change).is_err());
         Ok(())
@@ -94,7 +94,7 @@ mod api {
     #[test]
     fn finalize_before_begin_fails_gracefully() -> Result<()> {
         let l = testing_logger().new(o!("test" => "finalize_before_begin_fails_gracefully"));
-        let mut raft = Raft::new_with_logger(
+        let mut raft = Raft::with_logger(
             &Config {
                 id: 1,
                 tag: "1".into(),
@@ -1325,7 +1325,7 @@ impl Scenario {
             .chain(old_configuration.learners().iter())
             .map(|&id| {
                 Some(
-                    Raft::new_with_logger(
+                    Raft::with_logger(
                         &Config {
                             id,
                             tag: id.to_string(),
@@ -1364,7 +1364,7 @@ impl Scenario {
         let new_peers = self.new_peers();
         info!(self.logger, "Creating new peers. {:?}", new_peers);
         for &id in new_peers.voters() {
-            let raft = Raft::new_with_logger(
+            let raft = Raft::with_logger(
                 &Config {
                     id,
                     tag: id.to_string(),
@@ -1376,7 +1376,7 @@ impl Scenario {
             self.peers.insert(id, raft.into());
         }
         for &id in new_peers.learners() {
-            let raft = Raft::new_with_logger(
+            let raft = Raft::with_logger(
                 &Config {
                     id,
                     tag: id.to_string(),
@@ -1573,7 +1573,7 @@ impl Scenario {
             let mut peer = self.peers.remove(&id).expect("Peer did not exist.");
             let store = peer.mut_store().clone();
 
-            let mut peer = Raft::new_with_logger(
+            let mut peer = Raft::with_logger(
                 &Config {
                     id,
                     tag: id.to_string(),

--- a/harness/tests/integration_cases/test_membership_changes.rs
+++ b/harness/tests/integration_cases/test_membership_changes.rs
@@ -39,15 +39,15 @@ mod api {
     #[test]
     fn can_transition() -> Result<()> {
         let l = testing_logger().new(o!("test" => "can_transition"));
-        let mut raft = Raft::new(
+        let mut raft = Raft::new_with_logger(
             &Config {
                 id: 1,
                 tag: "1".into(),
                 ..Default::default()
             },
             MemStorage::new_with_conf_state((vec![1], vec![])),
-        )?
-        .with_logger(&l);
+            &l,
+        )?;
         let begin_conf_change = begin_conf_change(&[1, 2, 3], &[4], raft.raft_log.last_index() + 1);
         raft.begin_membership_change(&begin_conf_change)?;
         let finalize_conf_change = finalize_conf_change();
@@ -59,15 +59,15 @@ mod api {
     #[test]
     fn checks_for_overlapping_membership() -> Result<()> {
         let l = testing_logger().new(o!("test" => "checks_for_overlapping_membership"));
-        let mut raft = Raft::new(
+        let mut raft = Raft::new_with_logger(
             &Config {
                 id: 1,
                 tag: "1".into(),
                 ..Default::default()
             },
             MemStorage::new_with_conf_state((vec![1], vec![])),
-        )?
-        .with_logger(&l);
+            &l,
+        )?;
         let begin_conf_change =
             begin_conf_change(&[1, 2, 3], &[1, 2, 3], raft.raft_log.last_index() + 1);
         assert!(raft.begin_membership_change(&begin_conf_change).is_err());
@@ -84,7 +84,7 @@ mod api {
             ..Default::default()
         };
         let store = MemStorage::new_with_conf_state((vec![1, 2, 3], vec![4]));
-        let mut raft = Raft::new(&config, store)?.with_logger(&l);
+        let mut raft = Raft::new_with_logger(&config, store, &l)?;
         let begin_conf_change = begin_conf_change(&[1, 2], &[3, 4], raft.raft_log.last_index() + 1);
         assert!(raft.begin_membership_change(&begin_conf_change).is_err());
         Ok(())
@@ -94,15 +94,15 @@ mod api {
     #[test]
     fn finalize_before_begin_fails_gracefully() -> Result<()> {
         let l = testing_logger().new(o!("test" => "finalize_before_begin_fails_gracefully"));
-        let mut raft = Raft::new(
+        let mut raft = Raft::new_with_logger(
             &Config {
                 id: 1,
                 tag: "1".into(),
                 ..Default::default()
             },
             MemStorage::new_with_conf_state((vec![1, 2, 3], vec![4])),
-        )?
-        .with_logger(&l);
+            &l,
+        )?;
         let finalize_conf_change = finalize_conf_change();
         assert!(raft
             .finalize_membership_change(&finalize_conf_change)
@@ -1325,16 +1325,16 @@ impl Scenario {
             .chain(old_configuration.learners().iter())
             .map(|&id| {
                 Some(
-                    Raft::new(
+                    Raft::new_with_logger(
                         &Config {
                             id,
                             tag: id.to_string(),
                             ..Default::default()
                         },
                         MemStorage::new_with_conf_state(old_configuration.clone()),
+                        &logger,
                     )
                     .unwrap()
-                    .with_logger(&logger)
                     .into(),
                 )
             })
@@ -1364,27 +1364,27 @@ impl Scenario {
         let new_peers = self.new_peers();
         info!(self.logger, "Creating new peers. {:?}", new_peers);
         for &id in new_peers.voters() {
-            let raft = Raft::new(
+            let raft = Raft::new_with_logger(
                 &Config {
                     id,
                     tag: id.to_string(),
                     ..Default::default()
                 },
                 MemStorage::new_with_conf_state((vec![self.old_leader, id], vec![])),
-            )?
-            .with_logger(&self.logger);
+                &self.logger,
+            )?;
             self.peers.insert(id, raft.into());
         }
         for &id in new_peers.learners() {
-            let raft = Raft::new(
+            let raft = Raft::new_with_logger(
                 &Config {
                     id,
                     tag: id.to_string(),
                     ..Default::default()
                 },
                 MemStorage::new_with_conf_state((vec![self.old_leader], vec![id])),
-            )?
-            .with_logger(&self.logger);
+                &self.logger,
+            )?;
             self.peers.insert(id, raft.into());
         }
         Ok(())
@@ -1573,7 +1573,7 @@ impl Scenario {
             let mut peer = self.peers.remove(&id).expect("Peer did not exist.");
             let store = peer.mut_store().clone();
 
-            let mut peer = Raft::new(
+            let mut peer = Raft::new_with_logger(
                 &Config {
                     id,
                     tag: id.to_string(),
@@ -1581,9 +1581,9 @@ impl Scenario {
                     ..Default::default()
                 },
                 store,
+                &self.logger,
             )
-            .expect("Could not create new Raft")
-            .with_logger(&self.logger);
+            .expect("Could not create new Raft");
 
             if let Some(ref snapshot) = snapshot {
                 peer.restore(snapshot.clone());

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -74,7 +74,7 @@ fn new_raw_node(
     if !peers.is_empty() && !storage.initial_state().unwrap().initialized() {
         storage.initialize_with_conf_state((peers, vec![]));
     }
-    RawNode::new(&config, storage).unwrap().with_logger(logger)
+    RawNode::new_with_logger(&config, storage, logger).unwrap()
 }
 
 // test_raw_node_step ensures that RawNode.Step ignore local message.
@@ -413,9 +413,7 @@ fn test_raw_node_restart_from_snapshot() {
         store.wl().apply_snapshot(snap).unwrap();
         store.wl().append(&entries).unwrap();
         store.wl().set_hardstate(hard_state(1, 3, 0));
-        RawNode::new(&new_test_config(1, 10, 1), store)
-            .unwrap()
-            .with_logger(&l)
+        RawNode::new_with_logger(&new_test_config(1, 10, 1), store, &l).unwrap()
     };
 
     let rd = raw_node.ready();

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -74,7 +74,7 @@ fn new_raw_node(
     if !peers.is_empty() && !storage.initial_state().unwrap().initialized() {
         storage.initialize_with_conf_state((peers, vec![]));
     }
-    RawNode::new_with_logger(&config, storage, logger).unwrap()
+    RawNode::with_logger(&config, storage, logger).unwrap()
 }
 
 // test_raw_node_step ensures that RawNode.Step ignore local message.
@@ -413,7 +413,7 @@ fn test_raw_node_restart_from_snapshot() {
         store.wl().apply_snapshot(snap).unwrap();
         store.wl().append(&entries).unwrap();
         store.wl().set_hardstate(hard_state(1, 3, 0));
-        RawNode::new_with_logger(&new_test_config(1, 10, 1), store, &l).unwrap()
+        RawNode::with_logger(&new_test_config(1, 10, 1), store, &l).unwrap()
     };
 
     let rd = raw_node.ready();

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -118,7 +118,7 @@ pub fn new_test_raft_with_logs(
 }
 
 pub fn new_test_raft_with_config(config: &Config, storage: MemStorage, l: &Logger) -> Interface {
-    Interface::new(Raft::new(config, storage).unwrap().with_logger(l))
+    Interface::new(Raft::new_with_logger(config, storage, l).unwrap())
 }
 
 pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -118,7 +118,7 @@ pub fn new_test_raft_with_logs(
 }
 
 pub fn new_test_raft_with_config(config: &Config, storage: MemStorage, l: &Logger) -> Interface {
-    Interface::new(Raft::new_with_logger(config, storage, l).unwrap())
+    Interface::new(Raft::with_logger(config, storage, l).unwrap())
 }
 
 pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {

--- a/src/progress/progress_set.rs
+++ b/src/progress/progress_set.rs
@@ -178,14 +178,17 @@ impl ProgressSet {
     }
 
     /// Creates a new ProgressSet with the given logger.
-    pub fn new_with_logger(logger: &Logger) -> Self {
-        let mut prs = Self::new();
-        prs.logger = logger.new(o!());
-        prs
+    pub fn with_logger(logger: &Logger) -> Self {
+        Self::with_capacity_and_logger(0, 0, logger)
     }
 
     /// Create a progress set with the specified sizes already reserved.
     pub fn with_capacity(voters: usize, learners: usize) -> Self {
+        Self::with_capacity_and_logger(voters, learners, &default_logger())
+    }
+
+    /// Create a progress set with the specified sizes already reserved.
+    pub fn with_capacity_and_logger(voters: usize, learners: usize, logger: &Logger) -> Self {
         ProgressSet {
             progress: HashMap::with_capacity_and_hasher(
                 voters + learners,
@@ -195,7 +198,7 @@ impl ProgressSet {
             configuration_capacity: (voters, learners),
             configuration: Configuration::with_capacity(voters, learners),
             next_configuration: Option::default(),
-            logger: default_logger().new(o!()),
+            logger: logger.new(o!()),
         }
     }
 
@@ -205,7 +208,7 @@ impl ProgressSet {
         max_inflight: usize,
         logger: &Logger,
     ) -> Self {
-        let mut prs = ProgressSet::new_with_logger(logger);
+        let mut prs = ProgressSet::with_logger(logger);
 
         let pr = Progress::new(next_idx, max_inflight);
         meta.get_conf_state().nodes.iter().for_each(|id| {
@@ -690,7 +693,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_redundant_voter() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_redundant_voter"));
-        let mut set = ProgressSet::new_with_logger(&l);
+        let mut set = ProgressSet::with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -710,7 +713,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_redundant_learner() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_redundant_learner"));
-        let mut set = ProgressSet::new_with_logger(&l);
+        let mut set = ProgressSet::with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -730,7 +733,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_learner_that_is_voter() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_learner_that_is_voter"));
-        let mut set = ProgressSet::new_with_logger(&l);
+        let mut set = ProgressSet::with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -750,7 +753,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_voter_that_is_learner() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_voter_that_is_learner"));
-        let mut set = ProgressSet::new_with_logger(&l);
+        let mut set = ProgressSet::with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -770,7 +773,7 @@ mod test_progress_set {
     #[test]
     fn test_promote_learner() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_promote_learner"));
-        let mut set = ProgressSet::new_with_logger(&l);
+        let mut set = ProgressSet::with_logger(&l);
         let default_progress = Progress::new(0, 256);
         set.insert_voter(1, default_progress)?;
         let pre = set.get(1).expect("Should have been inserted").clone();
@@ -848,7 +851,7 @@ mod test_progress_set {
             .cloned()
             .collect::<HashSet<u64>>();
 
-        let mut set = ProgressSet::new_with_logger(&l);
+        let mut set = ProgressSet::with_logger(&l);
         let default_progress = Progress::new(0, 10);
 
         for starter in start_voters {

--- a/src/progress/progress_set.rs
+++ b/src/progress/progress_set.rs
@@ -177,6 +177,13 @@ impl ProgressSet {
         Self::with_capacity(0, 0)
     }
 
+    /// Creates a new ProgressSet with the given logger.
+    pub fn new_with_logger(logger: &Logger) -> Self {
+        let mut prs = Self::new();
+        prs.logger = logger.new(o!());
+        prs
+    }
+
     /// Create a progress set with the specified sizes already reserved.
     pub fn with_capacity(voters: usize, learners: usize) -> Self {
         ProgressSet {
@@ -192,20 +199,13 @@ impl ProgressSet {
         }
     }
 
-    /// Set a logger.
-    #[inline(always)]
-    pub fn with_logger(mut self, logger: &Logger) -> Self {
-        self.logger = logger.new(o!());
-        self
-    }
-
     pub(crate) fn restore_snapmeta(
         meta: &SnapshotMetadata,
         next_idx: u64,
         max_inflight: usize,
         logger: &Logger,
     ) -> Self {
-        let mut prs = ProgressSet::new().with_logger(logger);
+        let mut prs = ProgressSet::new_with_logger(logger);
 
         let pr = Progress::new(next_idx, max_inflight);
         meta.get_conf_state().nodes.iter().for_each(|id| {
@@ -690,7 +690,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_redundant_voter() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_redundant_voter"));
-        let mut set = ProgressSet::new().with_logger(&l);
+        let mut set = ProgressSet::new_with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -710,7 +710,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_redundant_learner() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_redundant_learner"));
-        let mut set = ProgressSet::new().with_logger(&l);
+        let mut set = ProgressSet::new_with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -730,7 +730,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_learner_that_is_voter() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_learner_that_is_voter"));
-        let mut set = ProgressSet::new().with_logger(&l);
+        let mut set = ProgressSet::new_with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -750,7 +750,7 @@ mod test_progress_set {
     #[test]
     fn test_insert_voter_that_is_learner() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_insert_voter_that_is_learner"));
-        let mut set = ProgressSet::new().with_logger(&l);
+        let mut set = ProgressSet::new_with_logger(&l);
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -770,7 +770,7 @@ mod test_progress_set {
     #[test]
     fn test_promote_learner() -> Result<()> {
         let l = default_logger().new(o!("test" => "test_promote_learner"));
-        let mut set = ProgressSet::new().with_logger(&l);
+        let mut set = ProgressSet::new_with_logger(&l);
         let default_progress = Progress::new(0, 256);
         set.insert_voter(1, default_progress)?;
         let pre = set.get(1).expect("Should have been inserted").clone();
@@ -848,7 +848,7 @@ mod test_progress_set {
             .cloned()
             .collect::<HashSet<u64>>();
 
-        let mut set = ProgressSet::new().with_logger(&l);
+        let mut set = ProgressSet::new_with_logger(&l);
         let default_progress = Progress::new(0, 10);
 
         for starter in start_voters {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -241,9 +241,12 @@ impl<T: Storage> Raft<T> {
     /// Creates a new raft for use on the node.
     #[allow(clippy::new_ret_no_self)]
     pub fn new(c: &Config, store: T) -> Result<Raft<T>> {
-        let logger = default_logger().new(o!(
-            "id" => c.id,
-        ));
+        Self::new_with_logger(c, store, &default_logger())
+    }
+
+    /// Creates a new raft for use on the node.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new_with_logger(c: &Config, store: T, logger: &Logger) -> Result<Raft<T>> {
         c.validate()?;
         let raft_state = store.initial_state()?;
         let conf_state = &raft_state.conf_state;
@@ -253,10 +256,10 @@ impl<T: Storage> Raft<T> {
         let mut r = Raft {
             id: c.id,
             read_states: Default::default(),
-            raft_log: RaftLog::new(store, c.tag.clone()),
+            raft_log: RaftLog::new_with_logger(store, c.tag.clone(), logger),
             max_inflight: c.max_inflight_msgs,
             max_msg_size: c.max_size_per_msg,
-            prs: Some(ProgressSet::with_capacity(peers.len(), learners.len())),
+            prs: Some(ProgressSet::new_with_logger(logger)),
             pending_request_snapshot: INVALID_INDEX,
             state: StateRole::Follower,
             is_learner: false,
@@ -281,7 +284,7 @@ impl<T: Storage> Raft<T> {
             skip_bcast_commit: c.skip_bcast_commit,
             tag: c.tag.to_owned(),
             batch_append: c.batch_append,
-            logger,
+            logger: logger.new(o!("id" => c.id)),
         };
         for p in peers {
             let pr = Progress::new(1, r.max_inflight);
@@ -332,17 +335,6 @@ impl<T: Storage> Raft<T> {
             "pending membership change" => ?r.pending_membership_change(),
         );
         Ok(r)
-    }
-
-    /// Set a logger.
-    #[inline(always)]
-    pub fn with_logger(mut self, logger: &Logger) -> Self {
-        self.logger = logger.new(o!(
-            "id" => self.id,
-        ));
-        self.raft_log = self.raft_log.with_logger(logger);
-        self.prs = self.prs.map(|prs| prs.with_logger(logger));
-        self
     }
 
     /// Grabs an immutable reference to the store.

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -97,9 +97,14 @@ where
 impl<T: Storage> RaftLog<T> {
     /// Creates a new raft log with a given storage and tag.
     pub fn new(store: T, tag: String) -> RaftLog<T> {
+        Self::new_with_logger(store, tag, &default_logger())
+    }
+
+    /// Creates a new raft log with a given storage and tag.
+    pub fn new_with_logger(store: T, tag: String, logger: &Logger) -> RaftLog<T> {
         let first_index = store.first_index().unwrap();
         let last_index = store.last_index().unwrap();
-        let logger = default_logger().new(o!("tag" => tag.clone()));
+        let logger = logger.new(o!("tag" => tag.clone()));
 
         // Initialize committed and applied pointers to the time of the last compaction.
         RaftLog {
@@ -110,15 +115,6 @@ impl<T: Storage> RaftLog<T> {
             tag,
             logger,
         }
-    }
-
-    /// Set a logger.
-    #[inline(always)]
-    pub fn with_logger(mut self, logger: &Logger) -> Self {
-        self.logger = logger.new(o!(
-            "tag" => self.tag.clone(),
-        ));
-        self
     }
 
     /// Grabs the term from the last entry.
@@ -546,7 +542,7 @@ mod test {
     use slog::Logger;
 
     fn new_raft_log(s: MemStorage, l: &Logger) -> RaftLog<MemStorage> {
-        RaftLog::new(s, String::from("")).with_logger(l)
+        RaftLog::new_with_logger(s, String::from(""), l)
     }
 
     fn new_entry(index: u64, term: u64) -> eraftpb::Entry {

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -97,11 +97,11 @@ where
 impl<T: Storage> RaftLog<T> {
     /// Creates a new raft log with a given storage and tag.
     pub fn new(store: T, tag: String) -> RaftLog<T> {
-        Self::new_with_logger(store, tag, &default_logger())
+        Self::with_logger(store, tag, &default_logger())
     }
 
     /// Creates a new raft log with a given storage and tag.
-    pub fn new_with_logger(store: T, tag: String, logger: &Logger) -> RaftLog<T> {
+    pub fn with_logger(store: T, tag: String, logger: &Logger) -> RaftLog<T> {
         let first_index = store.first_index().unwrap();
         let last_index = store.last_index().unwrap();
         let logger = logger.new(o!("tag" => tag.clone()));
@@ -542,7 +542,7 @@ mod test {
     use slog::Logger;
 
     fn new_raft_log(s: MemStorage, l: &Logger) -> RaftLog<MemStorage> {
-        RaftLog::new_with_logger(s, String::from(""), l)
+        RaftLog::with_logger(s, String::from(""), l)
     }
 
     fn new_entry(index: u64, term: u64) -> eraftpb::Entry {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -222,13 +222,13 @@ impl<T: Storage> RawNode<T> {
     #[allow(clippy::new_ret_no_self)]
     /// Create a new RawNode given some [`Config`](../struct.Config.html).
     pub fn new(config: &Config, store: T) -> Result<RawNode<T>> {
-        Self::new_with_logger(config, store, &default_logger())
+        Self::with_logger(config, store, &default_logger())
     }
 
     /// Create a new RawNode given some [`Config`](../struct.Config.html).
-    pub fn new_with_logger(config: &Config, store: T, logger: &Logger) -> Result<RawNode<T>> {
+    pub fn with_logger(config: &Config, store: T, logger: &Logger) -> Result<RawNode<T>> {
         assert_ne!(config.id, 0, "config.id must not be zero");
-        let r = Raft::new_with_logger(config, store, logger)?;
+        let r = Raft::with_logger(config, store, logger)?;
         let mut rn = RawNode {
             raft: r,
             prev_hs: Default::default(),

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -222,44 +222,23 @@ impl<T: Storage> RawNode<T> {
     #[allow(clippy::new_ret_no_self)]
     /// Create a new RawNode given some [`Config`](../struct.Config.html).
     pub fn new(config: &Config, store: T) -> Result<RawNode<T>> {
-        let logger = default_logger().new(o!());
-        assert_ne!(config.id, 0, "config.id must not be zero");
-        let r = Raft::new(config, store)?;
-        let mut rn = RawNode {
-            raft: r,
-            prev_hs: Default::default(),
-            prev_ss: Default::default(),
-            logger,
-        };
-        rn.prev_hs = rn.raft.hard_state();
-        rn.prev_ss = rn.raft.soft_state();
-        info!(rn.logger, "RawNode created with id {id}.", id = rn.raft.id);
-        Ok(rn)
+        Self::new_with_logger(config, store, &default_logger())
     }
 
     /// Create a new RawNode given some [`Config`](../struct.Config.html).
-    pub fn new_with_slog_global(config: &Config, store: T) -> Result<RawNode<T>> {
-        let logger = slog_global::get_global().new(o!());
+    pub fn new_with_logger(config: &Config, store: T, logger: &Logger) -> Result<RawNode<T>> {
         assert_ne!(config.id, 0, "config.id must not be zero");
-        let r = Raft::new(config, store)?;
+        let r = Raft::new_with_logger(config, store, logger)?;
         let mut rn = RawNode {
             raft: r,
             prev_hs: Default::default(),
             prev_ss: Default::default(),
-            logger,
+            logger: logger.new(o!()),
         };
         rn.prev_hs = rn.raft.hard_state();
         rn.prev_ss = rn.raft.soft_state();
         info!(rn.logger, "RawNode created with id {id}.", id = rn.raft.id);
         Ok(rn)
-    }
-
-    /// Set a logger.
-    #[inline(always)]
-    pub fn with_logger(mut self, logger: &Logger) -> Self {
-        self.logger = logger.new(o!());
-        self.raft = self.raft.with_logger(logger);
-        self
     }
 
     fn commit_ready(&mut self, rd: Ready) {


### PR DESCRIPTION
As the title described.
And some `with_logger` APIs removed because they are not necessary now.