### PR TITLE
Remove unnecessary trailing semicolon

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3530,12 +3530,11 @@ fn test_transfer_non_member() {
     let l = testing_logger().new(o!("test" => "transfer_non_member"));
     let mut raft = new_test_raft(1, vec![2, 3, 4], 5, 1, new_storage(), &l);
     raft.step(new_message(2, 1, MessageType::MsgTimeoutNow, 0))
-        .expect("");;
-
+        .expect("");
     raft.step(new_message(2, 1, MessageType::MsgRequestVoteResponse, 0))
-        .expect("");;
+        .expect("");
     raft.step(new_message(3, 1, MessageType::MsgRequestVoteResponse, 0))
-        .expect("");;
+        .expect("");
     assert_eq!(raft.state, StateRole::Follower);
 }
 


### PR DESCRIPTION
To fix the errors for CI based on nightly Rust version:
https://travis-ci.org/pingcap/raft-rs/jobs/573409951

![image](https://user-images.githubusercontent.com/12471960/63238083-508faa00-c277-11e9-9c3f-1173656384fd.png)

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>