### PR TITLE
Fix some linting complaints

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3530,12 +3530,12 @@ fn test_transfer_non_member() {
     let l = testing_logger().new(o!("test" => "transfer_non_member"));
     let mut raft = new_test_raft(1, vec![2, 3, 4], 5, 1, new_storage(), &l);
     raft.step(new_message(2, 1, MessageType::MsgTimeoutNow, 0))
-        .expect("");;
+        .expect("");
 
     raft.step(new_message(2, 1, MessageType::MsgRequestVoteResponse, 0))
-        .expect("");;
+        .expect("");
     raft.step(new_message(3, 1, MessageType::MsgRequestVoteResponse, 0))
-        .expect("");;
+        .expect("");
     assert_eq!(raft.state, StateRole::Follower);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ Here is a simple example to use `propose` and `step`:
 enum Msg {
     Propose {
         id: u8,
-        callback: Box<Fn() + Send>,
+        callback: Box<dyn Fn() + Send>,
     },
     Raft(Message),
 }
@@ -374,6 +374,8 @@ before taking old, removed peers offline.
 #![recursion_limit = "128"]
 // This is necessary to support prost and rust-protobuf at the same time.
 #![allow(clippy::identity_conversion)]
+// This lint recommends some bad choices sometimes.
+#![allow(clippy::unnecessary_unwrap)]
 
 #[cfg(feature = "failpoints")]
 #[macro_use]


### PR DESCRIPTION
I think these are just Clippy getting more picky. Split off from https://github.com/pingcap/raft-rs/pull/278.

The unnecessary unwrap is because there are some `if foo.is_some() && ... && ... { ... foo.unwrap() ... }` expressions where removing the unwrap means introducing an `if let` as well as a `let`, which I think is not worth doing. In any case, I don't really care I just want to un-break CI.

PTAL @brson @hicqu 