### PR TITLE
Update some deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,17 @@ protobuf = "2"
 slog = "2.2"
 quick-error = "1.2.2"
 raft-proto = { path = "proto", version = "0.6.0-alpha", default-features = false }
-rand = "0.7.0"
+# Stick with 0.6 (rather than 0.7) for now, since most of the ecosystem has not
+# upgraded yet and this saves duplicate deps.
+rand = "0.6.5"
 hashbrown = "0.5"
 fail = { version = "0.3", optional = true }
 getset = "0.0.7"
 slog-stdlog = "4"
 slog-envlogger = "2.1.0"
+# We don't actually use this crate, but by pinning to 0.5.1 it forces Cargo to
+# avoid 0.5.2 and thus pulling in a transitive dep with a security vulnerability.
+term = "=0.5.1"
 
 [dev-dependencies]
 criterion = ">0.2.4"

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -19,7 +19,7 @@ prost-codec = ["raft/prost-codec"]
 # Make sure to synchronize updates with Raft.
 [dependencies]
 raft = { path = "..", default-features = false }
-rand = "0.7.0"
+rand = "0.6.5"
 slog = "2.2"
 slog-term = "2.4.0"
 slog-envlogger = "2.1.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -18,7 +18,7 @@ protobuf-codec = ["protobuf-build/protobuf-codec"]
 prost-codec = ["prost", "prost-derive", "bytes", "lazy_static", "protobuf-build/prost-codec"]
 
 [build-dependencies]
-protobuf-build = { version = "0.9.1", default-features = false }
+protobuf-build = { version = "0.10", default-features = false }
 
 [dependencies]
 bytes = { version = "0.4.11", optional = true }


### PR DESCRIPTION
This avoids a security vuln in memoffset and moves us to the same version of protobuf-build as the rest of our ecosystem, which reduces deps in TiKV. I also downgrade rand to 0.6.5, every other Crate we use uses rand 0.6, so this lets us avoid a lot of duplicate deps in TiKV. I don't see any reason to rush into using rand 0.7.

PTAL @Hoverbear @hicqu 