### PR TITLE
*: clean up the usage of slog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ prost-codec = ["raft-proto/prost-codec"]
 
 # Make sure to synchronize updates with Harness.
 [dependencies]
-log = "0.4"
 protobuf = "2"
 slog = "2.2"
 quick-error = "1.2.2"
@@ -35,15 +34,12 @@ rand = "0.6.5"
 hashbrown = "0.5"
 fail = { version = "0.3", optional = true }
 getset = "0.0.7"
-slog-stdlog = "4"
-slog-envlogger = "2.1.0"
-# We don't actually use this crate, but by pinning to 0.5.1 it forces Cargo to
-# avoid 0.5.2 and thus pulling in a transitive dep with a security vulnerability.
-term = "=0.5.1"
 
 [dev-dependencies]
 criterion = ">0.2.4"
 regex = "1.1"
+slog-stdlog = "4"
+slog-envlogger = "2.1.0"
 slog-async = "2.3.0"
 slog-term = "2.4.0"
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,12 +1,44 @@
 #![allow(dead_code)] // Due to criterion we need this to avoid warnings.
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::let_and_return))] // Benches often artificially return values. Allow it.
 
+#[macro_use]
+extern crate slog;
+
 use criterion::Criterion;
 use std::time::Duration;
 
 mod suites;
 
 pub const DEFAULT_RAFT_SETS: [(usize, usize); 4] = [(0, 0), (3, 1), (5, 2), (7, 3)];
+
+/// The default logger we fall back to when passed `None` in external facing constructors.
+///
+/// Currently, this is a `log` adaptor behind a `Once` to ensure there is no clobbering.
+fn default_logger() -> slog::Logger {
+    use slog::Drain;
+    use std::sync::{Mutex, Once};
+
+    static LOGGER_INITIALIZED: Once = Once::new();
+    static mut LOGGER: Option<slog::Logger> = None;
+
+    let logger = unsafe {
+        LOGGER_INITIALIZED.call_once(|| {
+            let decorator = slog_term::TermDecorator::new().build();
+            let drain = slog_term::CompactFormat::new(decorator).build();
+            let drain = slog_envlogger::new(drain);
+            LOGGER = Some(slog::Logger::root(Mutex::new(drain).fuse(), o!()));
+        });
+        LOGGER.as_ref().unwrap()
+    };
+    let case = std::thread::current()
+        .name()
+        .unwrap()
+        .split(":")
+        .last()
+        .unwrap()
+        .to_string();
+    logger.new(o!("case" => case))
+}
 
 fn main() {
     let mut c = Criterion::default()

--- a/benches/suites/progress_set.rs
+++ b/benches/suites/progress_set.rs
@@ -16,7 +16,7 @@ pub fn bench_progress_set(c: &mut Criterion) {
 }
 
 fn quick_progress_set(voters: usize, learners: usize) -> ProgressSet {
-    let mut set = ProgressSet::with_capacity(voters, learners);
+    let mut set = ProgressSet::with_capacity(voters, learners, crate::default_logger());
     (0..voters).for_each(|id| {
         set.insert_voter(id as u64, Progress::new(0, 10)).ok();
     });
@@ -29,7 +29,7 @@ fn quick_progress_set(voters: usize, learners: usize) -> ProgressSet {
 pub fn bench_progress_set_new(c: &mut Criterion) {
     let bench = |b: &mut Bencher| {
         // No setup.
-        b.iter(|| ProgressSet::new());
+        b.iter(|| ProgressSet::new(crate::default_logger()));
     };
 
     c.bench_function("ProgressSet::new", bench);
@@ -39,7 +39,7 @@ pub fn bench_progress_set_with_capacity(c: &mut Criterion) {
     let bench = |voters, learners| {
         move |b: &mut Bencher| {
             // No setup.
-            b.iter(|| ProgressSet::with_capacity(voters, learners));
+            b.iter(|| ProgressSet::with_capacity(voters, learners, crate::default_logger()));
         }
     };
 

--- a/benches/suites/raft.rs
+++ b/benches/suites/raft.rs
@@ -1,5 +1,5 @@
 use crate::DEFAULT_RAFT_SETS;
-use criterion::{Bencher, Criterion};
+use criterion::Criterion;
 use raft::{storage::MemStorage, Config, Raft};
 
 pub fn bench_raft(c: &mut Criterion) {
@@ -7,11 +7,11 @@ pub fn bench_raft(c: &mut Criterion) {
     bench_raft_campaign(c);
 }
 
-fn quick_raft(voters: usize, learners: usize) -> Raft<MemStorage> {
+fn quick_raft(voters: usize, learners: usize, logger: &slog::Logger) -> Raft<MemStorage> {
     let id = 1;
     let storage = MemStorage::default();
     let config = Config::new(id);
-    let mut raft = Raft::new(&config, storage).unwrap();
+    let mut raft = Raft::new(&config, storage, logger).unwrap();
     (0..voters).for_each(|id| {
         raft.add_node(id as u64).unwrap();
     });
@@ -22,47 +22,36 @@ fn quick_raft(voters: usize, learners: usize) -> Raft<MemStorage> {
 }
 
 pub fn bench_raft_new(c: &mut Criterion) {
-    let bench = |voters, learners| {
-        move |b: &mut Bencher| {
-            // No setup.
-            b.iter(|| quick_raft(voters, learners));
-        }
-    };
-
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
-        c.bench_function(
-            &format!("Raft::new ({}, {})", voters, learners),
-            bench(*voters, *learners),
-        );
+        c.bench_function(&format!("Raft::new ({}, {})", voters, learners), move |b| {
+            let logger = crate::default_logger();
+            b.iter(|| quick_raft(*voters, *learners, &logger))
+        });
     });
 }
 
 pub fn bench_raft_campaign(c: &mut Criterion) {
-    let bench = |voters, learners, variant| {
-        move |b: &mut Bencher| {
-            b.iter(|| {
-                // TODO: Make raft clone somehow.
-                let mut raft = quick_raft(voters, learners);
-                raft.campaign(variant)
-            })
-        }
-    };
-
     DEFAULT_RAFT_SETS
         .iter()
         .skip(1)
         .for_each(|(voters, learners)| {
             // We don't want to make `raft::raft` public at this point.
-            let msgs = [
+            let msgs = &[
                 "CampaignPreElection",
                 "CampaignElection",
                 "CampaignTransfer",
             ];
             // Skip the first since it's 0,0
-            for msg in &msgs {
+            for msg in msgs {
                 c.bench_function(
                     &format!("Raft::campaign ({}, {}, {})", voters, learners, msg),
-                    bench(*voters, *learners, msg.as_bytes()),
+                    move |b| {
+                        let logger = crate::default_logger();
+                        b.iter(|| {
+                            let mut raft = quick_raft(*voters, *learners, &logger);
+                            raft.campaign(msg.as_bytes());
+                        })
+                    },
                 );
             }
         });

--- a/benches/suites/raw_node.rs
+++ b/benches/suites/raw_node.rs
@@ -5,17 +5,17 @@ pub fn bench_raw_node(c: &mut Criterion) {
     bench_raw_node_new(c);
 }
 
-fn quick_raw_node() -> RawNode<MemStorage> {
+fn quick_raw_node(logger: &slog::Logger) -> RawNode<MemStorage> {
     let id = 1;
     let storage = MemStorage::default();
     let config = Config::new(id);
-    RawNode::new(&config, storage).unwrap()
+    RawNode::new(&config, storage, logger).unwrap()
 }
 
 pub fn bench_raw_node_new(c: &mut Criterion) {
     let bench = |b: &mut Bencher| {
-        // No setup.
-        b.iter(quick_raw_node);
+        let logger = crate::default_logger();
+        b.iter(|| quick_raw_node(&logger));
     };
 
     c.bench_function("RawNode::new", bench);

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -47,19 +47,26 @@ use slog::{Drain, Logger};
 /// Currently, this is a terminal log. It ensures it is only initialized once to prevent clobbering.
 // This is `pub` so that testing and benching functions can use it.
 // `#[cfg(test)]` doesn't work for benching.
-#[doc(hidden)]
-pub fn testing_logger() -> &'static Logger {
+pub fn testing_logger() -> Logger {
     use std::sync::{Mutex, Once};
     static LOGGER_INITIALIZED: Once = Once::new();
     static mut LOGGER: Option<Logger> = None;
 
-    unsafe {
+    let logger = unsafe {
         LOGGER_INITIALIZED.call_once(|| {
             let decorator = slog_term::TermDecorator::new().build();
-            let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-            let drain = slog_envlogger::new(drain).fuse();
+            let drain = slog_term::CompactFormat::new(decorator).build();
+            let drain = slog_envlogger::new(drain);
             LOGGER = Some(slog::Logger::root(Mutex::new(drain).fuse(), o!()));
         });
         LOGGER.as_ref().unwrap()
-    }
+    };
+    let case = std::thread::current()
+        .name()
+        .unwrap()
+        .split(":")
+        .last()
+        .unwrap()
+        .to_string();
+    logger.new(o!("case" => case))
 }

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -102,8 +102,7 @@ impl Network {
                     nstorage.insert(*id, store.clone());
                     let mut config = config.clone();
                     config.id = *id;
-                    config.tag = id.to_string();
-                    let r = Raft::with_logger(&config, store, l).unwrap().into();
+                    let r = Raft::new(&config, store, l).unwrap().into();
                     npeers.insert(*id, r);
                 }
                 Some(r) => {

--- a/harness/tests/failpoints_cases/mod.rs
+++ b/harness/tests/failpoints_cases/mod.rs
@@ -24,7 +24,7 @@ use std::sync::*;
 #[test]
 fn test_reject_stale_term_message() {
     let scenario = fail::FailScenario::setup();
-    let l = testing_logger().new(o!("test" => "test_reject_stale_term_message"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     fail::cfg("before_step", "panic").unwrap();
     r.load_state(&hard_state(2, 1, 0));
@@ -40,7 +40,7 @@ fn test_reject_stale_term_message() {
 #[test]
 fn test_step_ignore_old_term_msg() {
     let scenario = fail::FailScenario::setup();
-    let l = testing_logger().new(o!("test" => "test_step_ignore_old_term_msg"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
     fail::cfg("before_step", "panic").unwrap();
     sm.term = 2;

--- a/harness/tests/integration_cases/test_membership_changes.rs
+++ b/harness/tests/integration_cases/test_membership_changes.rs
@@ -38,13 +38,9 @@ mod api {
     // Test that the cluster can transition from a single node to a whole cluster.
     #[test]
     fn can_transition() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "can_transition"));
-        let mut raft = Raft::with_logger(
-            &Config {
-                id: 1,
-                tag: "1".into(),
-                ..Default::default()
-            },
+        let l = testing_logger();
+        let mut raft = Raft::new(
+            &Config::new(1),
             MemStorage::new_with_conf_state((vec![1], vec![])),
             &l,
         )?;
@@ -58,13 +54,9 @@ mod api {
     // Test if the process rejects an overlapping voter and learner set.
     #[test]
     fn checks_for_overlapping_membership() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "checks_for_overlapping_membership"));
-        let mut raft = Raft::with_logger(
-            &Config {
-                id: 1,
-                tag: "1".into(),
-                ..Default::default()
-            },
+        let l = testing_logger();
+        let mut raft = Raft::new(
+            &Config::new(1),
             MemStorage::new_with_conf_state((vec![1], vec![])),
             &l,
         )?;
@@ -77,14 +69,10 @@ mod api {
     // Test if the process rejects an voter demotion.
     #[test]
     fn checks_for_voter_demotion() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "checks_for_voter_demotion"));
-        let config = Config {
-            id: 1,
-            tag: "1".into(),
-            ..Default::default()
-        };
+        let l = testing_logger();
+        let config = Config::new(1);
         let store = MemStorage::new_with_conf_state((vec![1, 2, 3], vec![4]));
-        let mut raft = Raft::with_logger(&config, store, &l)?;
+        let mut raft = Raft::new(&config, store, &l)?;
         let begin_conf_change = begin_conf_change(&[1, 2], &[3, 4], raft.raft_log.last_index() + 1);
         assert!(raft.begin_membership_change(&begin_conf_change).is_err());
         Ok(())
@@ -93,13 +81,9 @@ mod api {
     // Test if the process rejects an voter demotion.
     #[test]
     fn finalize_before_begin_fails_gracefully() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "finalize_before_begin_fails_gracefully"));
-        let mut raft = Raft::with_logger(
-            &Config {
-                id: 1,
-                tag: "1".into(),
-                ..Default::default()
-            },
+        let l = testing_logger();
+        let mut raft = Raft::new(
+            &Config::new(1),
             MemStorage::new_with_conf_state((vec![1, 2, 3], vec![4])),
             &l,
         )?;
@@ -118,7 +102,7 @@ mod three_peers_add_voter {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 3, 4], vec![]);
@@ -175,7 +159,7 @@ mod three_peers_add_learner {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 3], vec![4]);
@@ -232,7 +216,7 @@ mod remove_learner {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![4]);
         let new_configuration = (vec![1, 2, 3], vec![]);
@@ -280,7 +264,7 @@ mod remove_voter {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2], vec![]);
@@ -328,7 +312,7 @@ mod remove_leader {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![2, 3], vec![]);
@@ -404,7 +388,7 @@ mod remove_leader {
     /// If the leader fails after the `Begin`, then recovers after the `Finalize`, the group should ignore it.
     #[test]
     fn leader_fails_and_recovers() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "leader_fails_and_recovers"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![2, 3], vec![]);
@@ -488,7 +472,7 @@ mod three_peers_replace_voter {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -540,7 +524,7 @@ mod three_peers_replace_voter {
     /// The leader power cycles before actually sending the messages.
     #[test]
     fn leader_power_cycles_no_compaction() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "leader_power_cycles_no_compaction"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -617,7 +601,7 @@ mod three_peers_replace_voter {
     /// The leader power cycles before actually sending the messages.
     #[test]
     fn leader_power_cycles_compacted_log() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "leader_power_cycles_compacted_log"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -706,7 +690,7 @@ mod three_peers_replace_voter {
     // Ensure if a peer in the old quorum fails, but the quorum is still big enough, it's ok.
     #[test]
     fn pending_delete_fails_after_begin() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "pending_delete_fails_after_begin"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -760,7 +744,7 @@ mod three_peers_replace_voter {
     // Ensure if a peer in the new quorum fails, but the quorum is still big enough, it's ok.
     #[test]
     fn pending_create_with_quorum_fails_after_begin() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "pending_create_with_quorum_fails_after_begin"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -805,7 +789,7 @@ mod three_peers_replace_voter {
     // Ensure if the peer pending a deletion and the peer pending a creation both fail it's still ok (so long as both quorums hold).
     #[test]
     fn pending_create_and_destroy_both_fail() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "pending_create_and_destroy_both_fail"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -851,7 +835,7 @@ mod three_peers_replace_voter {
     // Ensure if the old quorum fails during the joint state progress will halt until the peer group is recovered.
     #[test]
     fn old_quorum_fails() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "old_quorum_fails"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -939,7 +923,7 @@ mod three_peers_replace_voter {
     // Ensure if the new quorum fails during the joint state progress will halt until the peer group is recovered.
     #[test]
     fn new_quorum_fails() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "new_quorum_fails"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 4], vec![]);
@@ -1032,7 +1016,7 @@ mod three_peers_to_five_with_learner {
     /// In a steady state transition should proceed without issue.
     #[test]
     fn stable() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "stable"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 3, 4, 5], vec![6]);
@@ -1084,7 +1068,7 @@ mod three_peers_to_five_with_learner {
     /// In this, a single node (of 3) halts during the transition.
     #[test]
     fn minority_old_followers_halt_at_start() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "minority_old_followers_halt_at_start"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 3, 4, 5], vec![6]);
@@ -1153,7 +1137,7 @@ mod intermingled_config_changes {
     // In this test, we make sure that if the peer group is sent a `BeginMembershipChange`, then immediately a `AddNode` entry, that the `AddNode` is rejected by the leader.
     #[test]
     fn begin_then_add_node() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "begin_then_add_node"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 3, 4], vec![]);
@@ -1220,7 +1204,7 @@ mod compaction {
     // Ensure that if a Raft compacts its log before finalizing that there are no failures.
     #[test]
     fn begin_compact_then_finalize() -> Result<()> {
-        let l = testing_logger().new(o!("test" => "begin_compact_then_finalize"));
+        let l = testing_logger();
         let leader = 1;
         let old_configuration = (vec![1, 2, 3], vec![]);
         let new_configuration = (vec![1, 2, 3], vec![4]);
@@ -1312,7 +1296,6 @@ impl Scenario {
         new_configuration: impl Into<Configuration>,
         logger: &slog::Logger,
     ) -> Result<Scenario> {
-        let logger = logger.new(o!());
         let old_configuration = old_configuration.into();
         let new_configuration = new_configuration.into();
         info!(
@@ -1325,14 +1308,10 @@ impl Scenario {
             .chain(old_configuration.learners().iter())
             .map(|&id| {
                 Some(
-                    Raft::with_logger(
-                        &Config {
-                            id,
-                            tag: id.to_string(),
-                            ..Default::default()
-                        },
+                    Raft::new(
+                        &Config::new(id),
                         MemStorage::new_with_conf_state(old_configuration.clone()),
-                        &logger,
+                        logger,
                     )
                     .unwrap()
                     .into(),
@@ -1344,7 +1323,7 @@ impl Scenario {
             old_configuration,
             new_configuration,
             network: Network::new(starting_peers, &logger),
-            logger,
+            logger: logger.clone(),
         };
         // Elect the leader.
         info!(
@@ -1364,24 +1343,16 @@ impl Scenario {
         let new_peers = self.new_peers();
         info!(self.logger, "Creating new peers. {:?}", new_peers);
         for &id in new_peers.voters() {
-            let raft = Raft::with_logger(
-                &Config {
-                    id,
-                    tag: id.to_string(),
-                    ..Default::default()
-                },
+            let raft = Raft::new(
+                &Config::new(id),
                 MemStorage::new_with_conf_state((vec![self.old_leader, id], vec![])),
                 &self.logger,
             )?;
             self.peers.insert(id, raft.into());
         }
         for &id in new_peers.learners() {
-            let raft = Raft::with_logger(
-                &Config {
-                    id,
-                    tag: id.to_string(),
-                    ..Default::default()
-                },
+            let raft = Raft::new(
+                &Config::new(id),
                 MemStorage::new_with_conf_state((vec![self.old_leader], vec![id])),
                 &self.logger,
             )?;
@@ -1573,11 +1544,10 @@ impl Scenario {
             let mut peer = self.peers.remove(&id).expect("Peer did not exist.");
             let store = peer.mut_store().clone();
 
-            let mut peer = Raft::with_logger(
+            let mut peer = Raft::new(
                 &Config {
                     id,
-                    tag: id.to_string(),
-                    applied: applied,
+                    applied,
                     ..Default::default()
                 },
                 store,

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -297,7 +297,7 @@ fn test_progress_resume() {
 
 #[test]
 fn test_progress_leader() {
-    let l = testing_logger().new(o!("test" => "test_progress_leader"));
+    let l = testing_logger();
     let mut raft = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     raft.become_candidate();
     raft.become_leader();
@@ -324,7 +324,7 @@ fn test_progress_leader() {
 // heartbeat response.
 #[test]
 fn test_progress_resume_by_heartbeat_resp() {
-    let l = testing_logger().new(o!("test" => "progress_resume_by_heartbeat_resp"));
+    let l = testing_logger();
     let mut raft = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     raft.become_candidate();
     raft.become_leader();
@@ -342,7 +342,7 @@ fn test_progress_resume_by_heartbeat_resp() {
 
 #[test]
 fn test_progress_paused() {
-    let l = testing_logger().new(o!("test" => "progress_paused"));
+    let l = testing_logger();
     let mut raft = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     raft.become_candidate();
     raft.become_leader();
@@ -362,13 +362,13 @@ fn test_progress_paused() {
 
 #[test]
 fn test_leader_election() {
-    let l = testing_logger().new(o!("test" => "leader_election"));
+    let l = testing_logger();
     test_leader_election_with_config(false, &l);
 }
 
 #[test]
 fn test_leader_election_pre_vote() {
-    let l = testing_logger().new(o!("test" => "leader_election_pre_vote"));
+    let l = testing_logger();
     test_leader_election_with_config(true, &l);
 }
 
@@ -452,13 +452,13 @@ fn test_leader_election_with_config(pre_vote: bool, l: &Logger) {
 
 #[test]
 fn test_leader_cycle() {
-    let l = testing_logger().new(o!("test" => "leader_cycle"));
+    let l = testing_logger();
     test_leader_cycle_with_config(false, &l)
 }
 
 #[test]
 fn test_leader_cycle_pre_vote() {
-    let l = testing_logger().new(o!("test" => "leader_cycle_pre_vote"));
+    let l = testing_logger();
     test_leader_cycle_with_config(true, &l)
 }
 
@@ -497,13 +497,13 @@ fn test_leader_cycle_with_config(pre_vote: bool, l: &Logger) {
 
 #[test]
 fn test_leader_election_overwrite_newer_logs() {
-    let l = testing_logger().new(o!("test" => "leader_election_overwrite_newer_logs"));
+    let l = testing_logger();
     test_leader_election_overwrite_newer_logs_with_config(false, &l);
 }
 
 #[test]
 fn test_leader_election_overwrite_newer_logs_pre_vote() {
-    let l = testing_logger().new(o!("test" => "leader_election_overwrite_newer_logs_pre_vote"));
+    let l = testing_logger();
     test_leader_election_overwrite_newer_logs_with_config(true, &l);
 }
 
@@ -579,13 +579,13 @@ fn test_leader_election_overwrite_newer_logs_with_config(pre_vote: bool, l: &Log
 
 #[test]
 fn test_vote_from_any_state() {
-    let l = testing_logger().new(o!("test" => "vote_from_any_state"));
+    let l = testing_logger();
     test_vote_from_any_state_for_type(MessageType::MsgRequestVote, &l);
 }
 
 #[test]
 fn test_prevote_from_any_state() {
-    let l = testing_logger().new(o!("test" => "prevote_from_any_state"));
+    let l = testing_logger();
     test_vote_from_any_state_for_type(MessageType::MsgRequestPreVote, &l);
 }
 
@@ -688,7 +688,7 @@ fn test_vote_from_any_state_for_type(vt: MessageType, l: &Logger) {
 
 #[test]
 fn test_log_replicatioin() {
-    let l = testing_logger().new(o!("test" => "log_replication"));
+    let l = testing_logger();
     let mut tests = vec![
         (
             Network::new(vec![None, None, None], &l),
@@ -740,7 +740,7 @@ fn test_log_replicatioin() {
 
 #[test]
 fn test_single_node_commit() {
-    let l = testing_logger().new(o!("test" => "single_node_commit"));
+    let l = testing_logger();
     let mut tt = Network::new(vec![None], &l);
     assert_eq!(tt.peers[&1].raft_log.first_index(), 2);
     tt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
@@ -754,7 +754,7 @@ fn test_single_node_commit() {
 // filtered.
 #[test]
 fn test_cannot_commit_without_new_term_entry() {
-    let l = testing_logger().new(o!("test" => "cannot_commit_without_new_term_entry"));
+    let l = testing_logger();
     let mut tt = Network::new(vec![None, None, None, None, None], &l);
     assert_eq!(tt.peers[&1].raft_log.committed, 1);
     tt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
@@ -794,7 +794,7 @@ fn test_cannot_commit_without_new_term_entry() {
 // when leader changes, no new proposal comes in.
 #[test]
 fn test_commit_without_new_term_entry() {
-    let l = testing_logger().new(o!("test" => "commit_without_new_term_entry"));
+    let l = testing_logger();
     let mut tt = Network::new(vec![None, None, None, None, None], &l);
     tt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -821,7 +821,7 @@ fn test_commit_without_new_term_entry() {
 
 #[test]
 fn test_dueling_candidates() {
-    let l = testing_logger().new(o!("test" => "dueling_candidates"));
+    let l = testing_logger();
     let a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -878,7 +878,7 @@ fn test_dueling_candidates() {
 
 #[test]
 fn test_dueling_pre_candidates() {
-    let l = testing_logger().new(o!("test" => "dueling_pre_candidates"));
+    let l = testing_logger();
     let a = new_test_raft_with_prevote(1, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
     let b = new_test_raft_with_prevote(2, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
     let c = new_test_raft_with_prevote(3, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
@@ -928,7 +928,7 @@ fn test_dueling_pre_candidates() {
 
 #[test]
 fn test_candidate_concede() {
-    let l = testing_logger().new(o!("test" => "progress_become_replicate"));
+    let l = testing_logger();
     let mut tt = Network::new(vec![None, None, None], &l);
     tt.isolate(1);
 
@@ -960,7 +960,7 @@ fn test_candidate_concede() {
 
 #[test]
 fn test_single_node_candidate() {
-    let l = testing_logger().new(o!("test" => "single_node_candidate"));
+    let l = testing_logger();
     let mut tt = Network::new(vec![None], &l);
     tt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -969,7 +969,7 @@ fn test_single_node_candidate() {
 
 #[test]
 fn test_sinle_node_pre_candidate() {
-    let l = testing_logger().new(o!("test" => "single_node_pre_candidate"));
+    let l = testing_logger();
     let mut config = Network::default_config();
     config.pre_vote = true;
     let mut tt = Network::new_with_config(vec![None], &config, &l);
@@ -980,7 +980,7 @@ fn test_sinle_node_pre_candidate() {
 
 #[test]
 fn test_old_messages() {
-    let l = testing_logger().new(o!("test" => "old_messages"));
+    let l = testing_logger();
     let mut tt = Network::new(vec![None, None, None], &l);
     // make 0 leader @ term 3
     tt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
@@ -1006,7 +1006,7 @@ fn test_old_messages() {
 
 #[test]
 fn test_proposal() {
-    let l = testing_logger().new(o!("test" => "proposal"));
+    let l = testing_logger();
     let mut tests = vec![
         (Network::new(vec![None, None, None], &l), true),
         (Network::new(vec![None, None, NOP_STEPPER], &l), true),
@@ -1051,7 +1051,7 @@ fn test_proposal() {
 
 #[test]
 fn test_proposal_by_proxy() {
-    let l = testing_logger().new(o!("test" => "proposal_by_proxy"));
+    let l = testing_logger();
     let mut tests = vec![
         Network::new(vec![None, None, None], &l),
         Network::new(vec![None, None, NOP_STEPPER], &l),
@@ -1080,7 +1080,7 @@ fn test_proposal_by_proxy() {
 
 #[test]
 fn test_commit() {
-    let l = testing_logger().new(o!("test" => "commit"));
+    let l = testing_logger();
     let mut tests = vec![
         // single
         (vec![2], vec![empty_entry(2, 2)], 2, 2),
@@ -1126,7 +1126,7 @@ fn test_commit() {
 
 #[test]
 fn test_pass_election_timeout() {
-    let l = testing_logger().new(o!("test" => "pass_election_timeout"));
+    let l = testing_logger();
     let tests = vec![
         (5, 0f64, false),
         (10, 0.1, true),
@@ -1164,7 +1164,7 @@ fn test_pass_election_timeout() {
 // 3. If leaderCommit > commitIndex, set commitIndex = min(leaderCommit, index of last new entry).
 #[test]
 fn test_handle_msg_append() {
-    let l = testing_logger().new(o!("test" => "handle_msg_append"));
+    let l = testing_logger();
     let nm = |term, log_term, index, commit, ents: Option<Vec<(u64, u64)>>| {
         let mut m = Message::default();
         m.set_msg_type(MessageType::MsgAppend);
@@ -1235,7 +1235,7 @@ fn test_handle_msg_append() {
 // test_handle_heartbeat ensures that the follower commits to the commit in the message.
 #[test]
 fn test_handle_heartbeat() {
-    let l = testing_logger().new(o!("test" => "handle_heartbeat"));
+    let l = testing_logger();
     let commit = 2u64;
     let nw = |f, to, term, commit| {
         let mut m = new_message(f, to, MessageType::MsgHeartbeat, 0);
@@ -1281,7 +1281,7 @@ fn test_handle_heartbeat() {
 // test_handle_heartbeat_resp ensures that we re-send log entries when we get a heartbeat response.
 #[test]
 fn test_handle_heartbeat_resp() {
-    let l = testing_logger().new(o!("test" => "handle_heartbeat_resp"));
+    let l = testing_logger();
     let store = new_storage();
     store
         .wl()
@@ -1325,7 +1325,7 @@ fn test_handle_heartbeat_resp() {
 // related issue: https://github.com/coreos/etcd/issues/7571
 #[test]
 fn test_raft_frees_read_only_mem() {
-    let l = testing_logger().new(o!("test" => "raft_frees_read_only_mem"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     sm.become_candidate();
     sm.become_leader();
@@ -1367,7 +1367,7 @@ fn test_raft_frees_read_only_mem() {
 // MsgAppResp.
 #[test]
 fn test_msg_append_response_wait_reset() {
-    let l = testing_logger().new(o!("test" => "msg_append_response_wait_reset"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2, 3], 5, 1, new_storage(), &l);
     sm.become_candidate();
     sm.become_leader();
@@ -1413,7 +1413,7 @@ fn test_msg_append_response_wait_reset() {
 
 #[test]
 fn test_recv_msg_request_vote() {
-    let l = testing_logger().new(o!("test" => "recv_msg_request_vote"));
+    let l = testing_logger();
     test_recv_msg_request_vote_for_type(MessageType::MsgRequestVote, &l);
 }
 
@@ -1485,7 +1485,7 @@ fn test_recv_msg_request_vote_for_type(msg_type: MessageType, l: &Logger) {
 
 #[test]
 fn test_state_transition() {
-    let l = testing_logger().new(o!("test" => "state_transition"));
+    let l = testing_logger();
     let mut tests = vec![
         (
             StateRole::Follower,
@@ -1598,7 +1598,7 @@ fn test_state_transition() {
 
 #[test]
 fn test_all_server_stepdown() {
-    let l = testing_logger().new(o!("test" => "all_server_stepdown"));
+    let l = testing_logger();
     let mut tests = vec![
         // state, want_state, term, last_index, entry count.
         (StateRole::Follower, StateRole::Follower, 3, 1, 0),
@@ -1661,13 +1661,13 @@ fn test_all_server_stepdown() {
 
 #[test]
 fn test_candidate_reset_term_msg_heartbeat() {
-    let l = testing_logger().new(o!("test" => "candidate_reset_term_msg_heartbeat"));
+    let l = testing_logger();
     test_candidate_reset_term(MessageType::MsgHeartbeat, &l)
 }
 
 #[test]
 fn test_candidate_reset_term_msg_append() {
-    let l = testing_logger().new(o!("test" => "candidate_reset_term_msg_append"));
+    let l = testing_logger();
     test_candidate_reset_term(MessageType::MsgAppend, &l)
 }
 
@@ -1728,7 +1728,7 @@ fn test_candidate_reset_term(message_type: MessageType, l: &Logger) {
 
 #[test]
 fn test_leader_stepdown_when_quorum_active() {
-    let l = testing_logger().new(o!("test" => "leader_stepdown_when_quorum_active"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2, 3], 5, 1, new_storage(), &l);
     sm.check_quorum = true;
     sm.become_candidate();
@@ -1746,7 +1746,7 @@ fn test_leader_stepdown_when_quorum_active() {
 
 #[test]
 fn test_leader_stepdown_when_quorum_lost() {
-    let l = testing_logger().new(o!("test" => "leader_stepdown_when_quorum_lost"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2, 3], 5, 1, new_storage(), &l);
 
     sm.check_quorum = true;
@@ -1763,7 +1763,7 @@ fn test_leader_stepdown_when_quorum_lost() {
 
 #[test]
 fn test_leader_superseding_with_check_quorum() {
-    let l = testing_logger().new(o!("test" => "leader_superseding_with_check_quorum"));
+    let l = testing_logger();
     let mut a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -1804,7 +1804,7 @@ fn test_leader_superseding_with_check_quorum() {
 
 #[test]
 fn test_leader_election_with_check_quorum() {
-    let l = testing_logger().new(o!("test" => "leader_election_with_check_quorum"));
+    let l = testing_logger();
     let mut a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -1866,7 +1866,7 @@ fn test_leader_election_with_check_quorum() {
 // leader is expected to step down and adopt the candidate's term
 #[test]
 fn test_free_stuck_candidate_with_check_quorum() {
-    let l = testing_logger().new(o!("test" => "free_stuck_candidate_with_check_quorum"));
+    let l = testing_logger();
     let mut a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -1920,7 +1920,7 @@ fn test_free_stuck_candidate_with_check_quorum() {
 
 #[test]
 fn test_non_promotable_voter_which_check_quorum() {
-    let l = testing_logger().new(o!("test" => "non_promotable_voter_which_check_quorum"));
+    let l = testing_logger();
     let mut a = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     let mut b = new_test_raft(2, vec![1], 10, 1, new_storage(), &l);
 
@@ -1961,7 +1961,7 @@ fn test_non_promotable_voter_which_check_quorum() {
 /// to step down.
 #[test]
 fn test_disruptive_follower() {
-    let l = testing_logger().new(o!("test" => "disruptive_follower"));
+    let l = testing_logger();
     let mut n1 = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut n2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut n3 = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -2052,7 +2052,7 @@ fn test_disruptive_follower() {
 /// current leader to step down, thus less disruptions.
 #[test]
 fn test_disruptive_follower_pre_vote() {
-    let l = testing_logger().new(o!("test" => "disruptive_follower_pre_vote"));
+    let l = testing_logger();
     let mut n1 = new_test_raft_with_prevote(1, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
     let mut n2 = new_test_raft_with_prevote(2, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
     let mut n3 = new_test_raft_with_prevote(3, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
@@ -2103,7 +2103,7 @@ fn test_disruptive_follower_pre_vote() {
 
 #[test]
 fn test_read_only_option_safe() {
-    let l = testing_logger().new(o!("test" => "read_only_option_safe"));
+    let l = testing_logger();
     let a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -2194,7 +2194,7 @@ fn test_read_only_option_safe() {
 
 #[test]
 fn test_read_only_with_learner() {
-    let l = testing_logger().new(o!("test" => "read_only_with_learner"));
+    let l = testing_logger();
     let a = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     let b = new_test_learner_raft(2, vec![1], vec![2], 10, 1, new_storage(), &l);
 
@@ -2267,7 +2267,7 @@ fn test_read_only_with_learner() {
 
 #[test]
 fn test_read_only_option_lease() {
-    let l = testing_logger().new(o!("test" => "read_only_option_lease"));
+    let l = testing_logger();
     let mut a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -2344,7 +2344,7 @@ fn test_read_only_option_lease() {
 
 #[test]
 fn test_read_only_option_lease_without_check_quorum() {
-    let l = testing_logger().new(o!("test" => "read_only_option_lease_without_check_quorum"));
+    let l = testing_logger();
     let mut a = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut b = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let mut c = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -2376,7 +2376,7 @@ fn test_read_only_option_lease_without_check_quorum() {
 // when it commits at least one log entry at it term.
 #[test]
 fn test_read_only_for_new_leader() {
-    let l = testing_logger().new(o!("test" => "read_only_for_new_leader"));
+    let l = testing_logger();
     let heartbeat_ticks = 1;
     let node_configs = vec![(1, 2, 2, 1), (2, 3, 3, 3), (3, 3, 3, 3)];
     let mut peers = vec![];
@@ -2454,7 +2454,7 @@ fn test_read_only_for_new_leader() {
 
 #[test]
 fn test_leader_append_response() {
-    let l = testing_logger().new(o!("test" => "leader_append_response"));
+    let l = testing_logger();
     // Initial progress: match = 0, next = 4 on followers.
     let mut tests = vec![
         // Stale resp; no replies.
@@ -2523,7 +2523,7 @@ fn test_leader_append_response() {
 // send a MsgApp with m.Index = 0, m.LogTerm=0 and empty entries.
 #[test]
 fn test_bcast_beat() {
-    let l = testing_logger().new(o!("test" => "bcast_beat"));
+    let l = testing_logger();
     let store = new_storage();
     let mut sm = new_test_raft(1, vec![1, 2, 3], 10, 1, store, &l);
 
@@ -2599,7 +2599,7 @@ fn test_bcast_beat() {
 // tests the output of the statemachine when receiving MsgBeat
 #[test]
 fn test_recv_msg_beat() {
-    let l = testing_logger().new(o!("test" => "recv_msg_beat"));
+    let l = testing_logger();
     let mut tests = vec![
         (StateRole::Leader, 2),
         // candidate and follower should ignore MsgBeat
@@ -2636,7 +2636,7 @@ fn test_recv_msg_beat() {
 
 #[test]
 fn test_leader_increase_next() {
-    let l = testing_logger().new(o!("test" => "leader_increase_next"));
+    let l = testing_logger();
     let previous_ents = vec![empty_entry(1, 2), empty_entry(1, 3), empty_entry(1, 4)];
     let mut tests = vec![
         // state replicate; optimistically increase next
@@ -2672,7 +2672,7 @@ fn test_leader_increase_next() {
 
 #[test]
 fn test_send_append_for_progress_probe() {
-    let l = testing_logger().new(o!("test" => "send_append_for_progress_probe"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
@@ -2725,7 +2725,7 @@ fn test_send_append_for_progress_probe() {
 
 #[test]
 fn test_send_append_for_progress_replicate() {
-    let l = testing_logger().new(o!("test" => "send_append_for_progress_replicate"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
@@ -2744,7 +2744,7 @@ fn test_send_append_for_progress_replicate() {
 
 #[test]
 fn test_send_append_for_progress_snapshot() {
-    let l = testing_logger().new(o!("test" => "send_append_for_progress_snapshot"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
@@ -2760,7 +2760,7 @@ fn test_send_append_for_progress_snapshot() {
 
 #[test]
 fn test_recv_msg_unreachable() {
-    let l = testing_logger().new(o!("test" => "recv_msg_unreachable"));
+    let l = testing_logger();
     let previous_ents = vec![empty_entry(1, 1), empty_entry(1, 2), empty_entry(1, 3)];
     let s = new_storage();
     s.wl().append(&previous_ents).unwrap();
@@ -2783,7 +2783,7 @@ fn test_recv_msg_unreachable() {
 
 #[test]
 fn test_restore() {
-    let l = testing_logger().new(o!("test" => "restore"));
+    let l = testing_logger();
     // magic number
     let s = new_snapshot(11, 11, vec![1, 2, 3]);
 
@@ -2808,7 +2808,7 @@ fn test_restore() {
 
 #[test]
 fn test_restore_ignore_snapshot() {
-    let l = testing_logger().new(o!("test" => "restore_ignore_snapshot"));
+    let l = testing_logger();
     let previous_ents = vec![empty_entry(1, 1), empty_entry(1, 2), empty_entry(1, 3)];
     let commit = 1u64;
     let mut sm = new_test_raft(1, vec![], 10, 1, new_storage(), &l);
@@ -2829,7 +2829,7 @@ fn test_restore_ignore_snapshot() {
 
 #[test]
 fn test_provide_snap() {
-    let l = testing_logger().new(o!("test" => "provide_snap"));
+    let l = testing_logger();
     // restore the state machine from a snapshot so it has a compacted log and a snapshot
     let s = new_snapshot(11, 11, vec![1, 2]); // magic number
 
@@ -2853,7 +2853,7 @@ fn test_provide_snap() {
 
 #[test]
 fn test_ignore_providing_snapshot() {
-    let l = testing_logger().new(o!("test" => "ignore_providing_snapshot"));
+    let l = testing_logger();
     // restore the state machine from a snapshot so it has a compacted log and a snapshot
     let s = new_snapshot(11, 11, vec![1, 2]); // magic number
     let mut sm = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
@@ -2875,7 +2875,7 @@ fn test_ignore_providing_snapshot() {
 
 #[test]
 fn test_restore_from_snap_msg() {
-    let l = testing_logger().new(o!("test" => "restore_from_snap_msg"));
+    let l = testing_logger();
     let s = new_snapshot(11, 11, vec![1, 2]); // magic number
     let mut sm = new_test_raft(2, vec![1, 2], 10, 1, new_storage(), &l);
     let mut m = new_message(1, 0, MessageType::MsgSnapshot, 0);
@@ -2891,7 +2891,7 @@ fn test_restore_from_snap_msg() {
 
 #[test]
 fn test_slow_node_restore() {
-    let l = testing_logger().new(o!("test" => "slow_node_restore"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -2934,7 +2934,7 @@ fn test_slow_node_restore() {
 // it appends the entry to log and sets pendingConf to be true.
 #[test]
 fn test_step_config() {
-    let l = testing_logger().new(o!("test" => "step_config"));
+    let l = testing_logger();
     // a raft that cannot make progress
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.become_candidate();
@@ -2953,7 +2953,7 @@ fn test_step_config() {
 // the proposal to noop and keep its original state.
 #[test]
 fn test_step_ignore_config() {
-    let l = testing_logger().new(o!("test" => "step_ignore_config"));
+    let l = testing_logger();
     // a raft that cannot make progress
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.become_candidate();
@@ -2981,7 +2981,7 @@ fn test_step_ignore_config() {
 // based on uncommitted entries.
 #[test]
 fn test_new_leader_pending_config() {
-    let l = testing_logger().new(o!("test" => "new_leader_pending_config"));
+    let l = testing_logger();
     let mut tests = vec![(false, 1), (true, 2)];
     for (i, (add_entry, wpending_index)) in tests.drain(..).enumerate() {
         let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
@@ -3005,7 +3005,7 @@ fn test_new_leader_pending_config() {
 // test_add_node tests that add_node could update nodes correctly.
 #[test]
 fn test_add_node() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "add_node"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
     r.add_node(2)?;
     assert_eq!(
@@ -3018,7 +3018,7 @@ fn test_add_node() -> Result<()> {
 
 #[test]
 fn test_add_node_check_quorum() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "add_node_check_quorum"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
 
     r.check_quorum = true;
@@ -3053,7 +3053,7 @@ fn test_add_node_check_quorum() -> Result<()> {
 // and removed list correctly.
 #[test]
 fn test_remove_node() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "remove_node"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.remove_node(2)?;
     assert_eq!(r.prs().voter_ids().iter().next().unwrap(), &1);
@@ -3066,7 +3066,7 @@ fn test_remove_node() -> Result<()> {
 
 #[test]
 fn test_promotable() {
-    let l = testing_logger().new(o!("test" => "promotable"));
+    let l = testing_logger();
     let id = 1u64;
     let mut tests = vec![
         (vec![1], true),
@@ -3084,7 +3084,7 @@ fn test_promotable() {
 
 #[test]
 fn test_raft_nodes() {
-    let l = testing_logger().new(o!("test" => "raft_nodes"));
+    let l = testing_logger();
     let mut tests = vec![
         (vec![1, 2, 3], vec![1, 2, 3]),
         (vec![3, 2, 1], vec![1, 2, 3]),
@@ -3101,13 +3101,13 @@ fn test_raft_nodes() {
 
 #[test]
 fn test_campaign_while_leader() {
-    let l = testing_logger().new(o!("test" => "campaign_while_leader"));
+    let l = testing_logger();
     test_campaign_while_leader_with_pre_vote(false, &l);
 }
 
 #[test]
 fn test_pre_campaign_while_leader() {
-    let l = testing_logger().new(o!("test" => "pre_campaign_while_leader"));
+    let l = testing_logger();
     test_campaign_while_leader_with_pre_vote(true, &l);
 }
 
@@ -3128,7 +3128,7 @@ fn test_campaign_while_leader_with_pre_vote(pre_vote: bool, l: &Logger) {
 // committed when a config change reduces the quorum requirements.
 #[test]
 fn test_commit_after_remove_node() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "commit_after_remove_node"));
+    let l = testing_logger();
     // Create a cluster with two nodes.
     let s = new_storage();
     let mut r = new_test_raft(1, vec![1, 2], 5, 1, s.clone(), &l);
@@ -3182,7 +3182,7 @@ fn test_commit_after_remove_node() -> Result<()> {
 // if the transferee has the most up-to-date log entries when transfer starts.
 #[test]
 fn test_leader_transfer_to_uptodate_node() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_to_uptodate_node"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3206,7 +3206,7 @@ fn test_leader_transfer_to_uptodate_node() {
 // to the follower.
 #[test]
 fn test_leader_transfer_to_uptodate_node_from_follower() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_to_uptodate_node_from_follower"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3227,7 +3227,7 @@ fn test_leader_transfer_to_uptodate_node_from_follower() {
 // even the current leader is still under its leader lease
 #[test]
 fn test_leader_transfer_with_check_quorum() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_with_check_quorum"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     for i in 1..4 {
         let r = &mut nt.peers.get_mut(&i).unwrap();
@@ -3262,7 +3262,7 @@ fn test_leader_transfer_with_check_quorum() {
 
 #[test]
 fn test_leader_transfer_to_slow_follower() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_to_slow_follower"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3280,7 +3280,7 @@ fn test_leader_transfer_to_slow_follower() {
 
 #[test]
 fn test_leader_transfer_after_snapshot() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_after_snapshot"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3315,7 +3315,7 @@ fn test_leader_transfer_after_snapshot() {
 
 #[test]
 fn test_leader_transfer_to_self() {
-    let l = testing_logger().new(o!("test" => "vote_request"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3326,7 +3326,7 @@ fn test_leader_transfer_to_self() {
 
 #[test]
 fn test_leader_transfer_to_non_existing_node() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_to_non_existing_node"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3337,7 +3337,7 @@ fn test_leader_transfer_to_non_existing_node() {
 
 #[test]
 fn test_leader_transfer_to_learner() {
-    let l = testing_logger().new(o!("test" => "test_leader_transfer_to_learner"));
+    let l = testing_logger();
     let s = MemStorage::new_with_conf_state((vec![1], vec![2]));
     let c = new_test_config(1, 10, 1);
     let leader = new_test_raft_with_config(&c, s, &l);
@@ -3356,7 +3356,7 @@ fn test_leader_transfer_to_learner() {
 
 #[test]
 fn test_leader_transfer_timeout() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_timeout"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3380,7 +3380,7 @@ fn test_leader_transfer_timeout() {
 
 #[test]
 fn test_leader_transfer_ignore_proposal() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_ignore_proposal"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3405,7 +3405,7 @@ fn test_leader_transfer_ignore_proposal() {
 
 #[test]
 fn test_leader_transfer_receive_higher_term_vote() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_recieve_higher_term_vote"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3427,7 +3427,7 @@ fn test_leader_transfer_receive_higher_term_vote() {
 
 #[test]
 fn test_leader_transfer_remove_node() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "leader_transfer_remove_node"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3448,7 +3448,7 @@ fn test_leader_transfer_remove_node() -> Result<()> {
 // back to self when last transfer is pending.
 #[test]
 fn test_leader_transfer_back() {
-    let l = testing_logger().new(o!("test" => "vote_request"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3467,7 +3467,7 @@ fn test_leader_transfer_back() {
 // when last transfer is pending.
 #[test]
 fn test_leader_transfer_second_transfer_to_another_node() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_second_transfer_to_another_node"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3486,7 +3486,7 @@ fn test_leader_transfer_second_transfer_to_another_node() {
 // to the same node should not extend the timeout while the first one is pending.
 #[test]
 fn test_leader_transfer_second_transfer_to_same_node() {
-    let l = testing_logger().new(o!("test" => "leader_transfer_second_transfer_to_same_node"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
 
@@ -3527,7 +3527,7 @@ fn check_leader_transfer_state(r: &Raft<MemStorage>, state: StateRole, lead: u64
 // transitioned to StateRole::Leader)
 #[test]
 fn test_transfer_non_member() {
-    let l = testing_logger().new(o!("test" => "transfer_non_member"));
+    let l = testing_logger();
     let mut raft = new_test_raft(1, vec![2, 3, 4], 5, 1, new_storage(), &l);
     raft.step(new_message(2, 1, MessageType::MsgTimeoutNow, 0))
         .expect("");
@@ -3546,7 +3546,7 @@ fn test_transfer_non_member() {
 // enabled.
 #[test]
 fn test_node_with_smaller_term_can_complete_election() {
-    let l = testing_logger().new(o!("test" => "node_with_smaller_term_can_complete_election"));
+    let l = testing_logger();
     let mut n1 = new_test_raft_with_prevote(1, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
     let mut n2 = new_test_raft_with_prevote(2, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
     let mut n3 = new_test_raft_with_prevote(3, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
@@ -3628,7 +3628,7 @@ pub fn new_test_learner_raft(
 // even when times out.
 #[test]
 fn test_learner_election_timeout() {
-    let l = testing_logger().new(o!("test" => "learner_election_timeout"));
+    let l = testing_logger();
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     n1.become_follower(1, INVALID_ID);
 
@@ -3649,7 +3649,7 @@ fn test_learner_election_timeout() {
 // it is promoted to a normal peer.
 #[test]
 fn test_learner_promotion() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "vote_request"));
+    let l = testing_logger();
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     n1.become_follower(1, INVALID_ID);
 
@@ -3703,7 +3703,7 @@ fn test_learner_promotion() -> Result<()> {
 // TestLearnerLogReplication tests that a learner can receive entries from the leader.
 #[test]
 fn test_learner_log_replication() {
-    let l = testing_logger().new(o!("test" => "learner_log_replication"));
+    let l = testing_logger();
     let n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     let n2 = new_test_learner_raft(2, vec![1], vec![2], 10, 1, new_storage(), &l);
     let mut network = Network::new(vec![Some(n1), Some(n2)], &l);
@@ -3759,7 +3759,7 @@ fn test_learner_log_replication() {
 // TestRestoreWithLearner restores a snapshot which contains learners.
 #[test]
 fn test_restore_with_learner() {
-    let l = testing_logger().new(o!("test" => "restore_with_learner"));
+    let l = testing_logger();
     let mut s = new_snapshot(11, 11, vec![1, 2]);
     s.mut_metadata().mut_conf_state().mut_learners().push(3);
 
@@ -3789,7 +3789,7 @@ fn test_restore_with_learner() {
 // when restores snapshot.
 #[test]
 fn test_restore_invalid_learner() {
-    let l = testing_logger().new(o!("test" => "restore_invalid_learner"));
+    let l = testing_logger();
     let mut s = new_snapshot(11, 11, vec![1, 2]);
     s.mut_metadata().mut_conf_state().mut_learners().push(3);
 
@@ -3800,7 +3800,7 @@ fn test_restore_invalid_learner() {
 
 #[test]
 fn test_restore_learner() {
-    let l = testing_logger().new(o!("test" => "restore_learner_promotion"));
+    let l = testing_logger();
     let mut s = new_snapshot(11, 11, vec![1, 2]);
     s.mut_metadata().mut_conf_state().mut_learners().push(3);
 
@@ -3814,7 +3814,7 @@ fn test_restore_learner() {
 // restoring snapshot.
 #[test]
 fn test_restore_learner_promotion() {
-    let l = testing_logger().new(o!("test" => "restore_learner_promotion"));
+    let l = testing_logger();
     let s = new_snapshot(11, 11, vec![1, 2, 3]);
     let mut sm = new_test_learner_raft(3, vec![1, 2], vec![3], 10, 1, new_storage(), &l);
     assert!(sm.is_learner);
@@ -3825,7 +3825,7 @@ fn test_restore_learner_promotion() {
 // TestLearnerReceiveSnapshot tests that a learner can receive a snapshot from leader.
 #[test]
 fn test_learner_receive_snapshot() {
-    let l = testing_logger().new(o!("test" => "learner_receive_snapshot"));
+    let l = testing_logger();
     let mut s = new_snapshot(11, 11, vec![1]);
     s.mut_metadata().mut_conf_state().mut_learners().push(2);
 
@@ -3863,7 +3863,7 @@ fn test_learner_receive_snapshot() {
 // TestAddLearner tests that addLearner could update nodes correctly.
 #[test]
 fn test_add_learner() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "add_learner"));
+    let l = testing_logger();
     let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
     n1.add_learner(2)?;
 
@@ -3877,7 +3877,7 @@ fn test_add_learner() -> Result<()> {
 // When the action fails, ensure it doesn't mutate the raft state.
 #[test]
 fn test_add_voter_peer_promotes_self_sets_is_learner() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "test_add_voter_peer_promotes_self_sets_is_learner"));
+    let l = testing_logger();
 
     let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
     // Node is already voter.
@@ -3896,7 +3896,7 @@ fn test_add_voter_peer_promotes_self_sets_is_learner() -> Result<()> {
 // and removed list correctly.
 #[test]
 fn test_remove_learner() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "remove_learner"));
+    let l = testing_logger();
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     n1.remove_node(2)?;
     assert_eq!(n1.prs().voter_ids().iter().next().unwrap(), &1);
@@ -3961,7 +3961,7 @@ fn new_prevote_migration_cluster(l: &Logger) -> Network {
 
 #[test]
 fn test_prevote_migration_can_complete_election() {
-    let l = testing_logger().new(o!("test" => "prevote_migration_with_free_stuck_pre_candidate"));
+    let l = testing_logger();
     // n1 is leader with term 2
     // n2 is follower with term 2
     // n3 is pre-candidate with term 4, and less log
@@ -3991,7 +3991,7 @@ fn test_prevote_migration_can_complete_election() {
 
 #[test]
 fn test_prevote_migration_with_free_stuck_pre_candidate() {
-    let l = testing_logger().new(o!("test" => "prevote_migration_with_free_stuck_pre_candidate"));
+    let l = testing_logger();
     let mut nt = new_prevote_migration_cluster(&l);
 
     // n1 is leader with term 2
@@ -4021,7 +4021,7 @@ fn test_prevote_migration_with_free_stuck_pre_candidate() {
 
 #[test]
 fn test_learner_respond_vote() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "learner_respond_vote"));
+    let l = testing_logger();
     let mut n1 = new_test_learner_raft(1, vec![1, 2], vec![3], 10, 1, new_storage(), &l);
     n1.become_follower(1, INVALID_ID);
     n1.reset_randomized_election_timeout();
@@ -4052,7 +4052,7 @@ fn test_learner_respond_vote() -> Result<()> {
 
 #[test]
 fn test_election_tick_range() {
-    let l = testing_logger().new(o!("test" => "election_tick_range"));
+    let l = testing_logger();
     let mut cfg = new_test_config(1, 10, 1);
     let s = MemStorage::new_with_conf_state((vec![1, 2, 3], vec![]));
     let mut raft = new_test_raft_with_config(&cfg, s, &l).raft.unwrap();
@@ -4091,7 +4091,7 @@ fn test_election_tick_range() {
 // election in next round.
 #[test]
 fn test_prevote_with_split_vote() {
-    let l = testing_logger().new(o!("test" => "prevote_with_split_vote"));
+    let l = testing_logger();
     let peers = (1..=3).map(|id| {
         let mut raft =
             new_test_raft_with_prevote(id, vec![1, 2, 3], 10, 1, new_storage(), true, &l);
@@ -4139,7 +4139,7 @@ fn test_prevote_with_split_vote() {
 // ensure that after a node become pre-candidate, it will checkQuorum correctly.
 #[test]
 fn test_prevote_with_check_quorum() {
-    let l = testing_logger().new(o!("test" => "prevote_with_check_quorum"));
+    let l = testing_logger();
     let bootstrap = |id| {
         let mut cfg = new_test_config(id, 10, 1);
         cfg.pre_vote = true;
@@ -4210,14 +4210,14 @@ fn test_prevote_with_check_quorum() {
 fn test_new_raft_with_bad_config_errors() {
     let invalid_config = new_test_config(INVALID_ID, 1, 1);
     let s = MemStorage::new_with_conf_state((vec![1, 2], vec![]));
-    let raft = Raft::new(&invalid_config, s);
+    let raft = Raft::new(&invalid_config, s, &testing_logger());
     assert!(raft.is_err())
 }
 
 // tests whether MsgAppend are batched
 #[test]
 fn test_batch_msg_append() {
-    let l = testing_logger().new(o!("test" => "test_batch_msg_append"));
+    let l = testing_logger();
     let storage = new_storage();
     let mut raft = new_test_raft(1, vec![1, 2, 3], 10, 1, storage.clone(), &l);
     raft.become_candidate();
@@ -4244,7 +4244,7 @@ fn test_batch_msg_append() {
 /// Tests if unapplied conf change is checked before campaign.
 #[test]
 fn test_conf_change_check_before_campaign() {
-    let l = testing_logger().new(o!("test" => "test_conf_change_check_before_campaign"));
+    let l = testing_logger();
     let mut nt = Network::new(vec![None, None, None], &l);
     nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
     assert_eq!(nt.peers[&1].state, StateRole::Leader);
@@ -4304,7 +4304,7 @@ fn test_conf_change_check_before_campaign() {
 }
 
 fn prepare_request_snapshot() -> (Network, Snapshot) {
-    let l = testing_logger().new(o!("test" => "log_replication"));
+    let l = testing_logger();
 
     fn index_term_11(id: u64, ids: Vec<u64>, l: &Logger) -> Interface {
         let store = MemStorage::new();

--- a/harness/tests/integration_cases/test_raft_flow_control.rs
+++ b/harness/tests/integration_cases/test_raft_flow_control.rs
@@ -43,7 +43,7 @@ where
 // 2. when the window is full, no more msgApp can be sent.
 #[test]
 fn test_msg_app_flow_control_full() {
-    let l = testing_logger().new(o!("test" => "msg_app_flow_control_full"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
@@ -83,7 +83,7 @@ fn test_msg_app_flow_control_full() {
 // 2. out-of-dated msgAppResp has no effect on the sliding window.
 #[test]
 fn test_msg_app_flow_control_move_forward() {
-    let l = testing_logger().new(o!("test" => "msg_app_flow_control_move_forward"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();
@@ -140,7 +140,7 @@ fn test_msg_app_flow_control_move_forward() {
 // frees one slot if the window is full.
 #[test]
 fn test_msg_app_flow_control_recv_heartbeat() {
-    let l = testing_logger().new(o!("test" => "msg_app_flow_control_recv_heartbeat"));
+    let l = testing_logger();
     let mut r = new_test_raft(1, vec![1, 2], 5, 1, new_storage(), &l);
     r.become_candidate();
     r.become_leader();

--- a/harness/tests/integration_cases/test_raft_paper.rs
+++ b/harness/tests/integration_cases/test_raft_paper.rs
@@ -64,19 +64,19 @@ fn accept_and_reply(m: &Message) -> Message {
 
 #[test]
 fn test_follower_update_term_from_message() {
-    let l = testing_logger().new(o!("test" => "candidate_update_term_from_message"));
+    let l = testing_logger();
     test_update_term_from_message(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidate_update_term_from_message() {
-    let l = testing_logger().new(o!("test" => "candidate_update_term_from_message"));
+    let l = testing_logger();
     test_update_term_from_message(StateRole::Candidate, &l);
 }
 
 #[test]
 fn test_leader_update_term_from_message() {
-    let l = testing_logger().new(o!("test" => "leader_update_term_from_message"));
+    let l = testing_logger();
     test_update_term_from_message(StateRole::Leader, &l);
 }
 
@@ -109,7 +109,7 @@ fn test_update_term_from_message(state: StateRole, l: &Logger) {
 // Reference: section 5.2
 #[test]
 fn test_start_as_follower() {
-    let l = testing_logger().new(o!("test" => "start_as_follower"));
+    let l = testing_logger();
     let r = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     assert_eq!(r.state, StateRole::Follower);
 }
@@ -120,7 +120,7 @@ fn test_start_as_follower() {
 // Reference: section 5.2
 #[test]
 fn test_leader_bcast_beat() {
-    let l = testing_logger().new(o!("test" => "leader_bcast_beat"));
+    let l = testing_logger();
     // heartbeat interval
     let hi = 1;
     let mut r = new_test_raft(1, vec![1, 2, 3], 10, hi, new_storage(), &l);
@@ -150,13 +150,13 @@ fn test_leader_bcast_beat() {
 
 #[test]
 fn test_follower_start_election() {
-    let l = testing_logger().new(o!("test" => "follower_start_election"));
+    let l = testing_logger();
     test_nonleader_start_election(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidate_start_new_election() {
-    let l = testing_logger().new(o!("test" => "candidate_start_new_election"));
+    let l = testing_logger();
     test_nonleader_start_election(StateRole::Candidate, &l);
 }
 
@@ -208,7 +208,7 @@ fn test_nonleader_start_election(state: StateRole, l: &Logger) {
 // Reference: section 5.2
 #[test]
 fn test_leader_election_in_one_round_rpc() {
-    let l = testing_logger().new(o!("test" => "leader_election_in_one_round_rpc"));
+    let l = testing_logger();
     let mut tests = vec![
         // win the election when receiving votes from a majority of the servers
         (1, map!(), StateRole::Leader),
@@ -265,7 +265,7 @@ fn test_leader_election_in_one_round_rpc() {
 // Reference: section 5.2
 #[test]
 fn test_follower_vote() {
-    let l = testing_logger().new(o!("test" => "follower_vote"));
+    let l = testing_logger();
     let mut tests = vec![
         (INVALID_ID, 1, false),
         (INVALID_ID, 2, false),
@@ -303,7 +303,7 @@ fn test_follower_vote() {
 // Reference: section 5.2
 #[test]
 fn test_candidate_fallback() {
-    let l = testing_logger().new(o!("test" => "candidate_fallback"));
+    let l = testing_logger();
     let new_message_ext = |f, to, term| {
         let mut m = new_message(f, to, MessageType::MsgAppend, 0);
         m.term = term;
@@ -334,13 +334,13 @@ fn test_candidate_fallback() {
 
 #[test]
 fn test_follower_election_timeout_randomized() {
-    let l = testing_logger().new(o!("test" => "follower_election_timeout_randomized"));
+    let l = testing_logger();
     test_non_leader_election_timeout_randomized(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidate_election_timeout_randomized() {
-    let l = testing_logger().new(o!("test" => "candidate_election_timeout_randomized"));
+    let l = testing_logger();
     test_non_leader_election_timeout_randomized(StateRole::Candidate, &l);
 }
 
@@ -375,13 +375,13 @@ fn test_non_leader_election_timeout_randomized(state: StateRole, l: &Logger) {
 
 #[test]
 fn test_follower_election_timeout_nonconflict() {
-    let l = testing_logger().new(o!("test" => "follower_election_timeoout_nonconflict"));
+    let l = testing_logger();
     test_nonleaders_election_timeout_nonconfict(StateRole::Follower, &l);
 }
 
 #[test]
 fn test_candidates_election_timeout_nonconf() {
-    let l = testing_logger().new(o!("test" => "candidates_election_timeout_nonconf"));
+    let l = testing_logger();
     test_nonleaders_election_timeout_nonconfict(StateRole::Candidate, &l);
 }
 
@@ -436,7 +436,7 @@ fn test_nonleaders_election_timeout_nonconfict(state: StateRole, l: &Logger) {
 // Reference: section 5.3
 #[test]
 fn test_leader_start_replication() {
-    let l = testing_logger().new(o!("test" => "leader_start_replication"));
+    let l = testing_logger();
     let s = new_storage();
     let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s.clone(), &l);
     r.become_candidate();
@@ -478,7 +478,7 @@ fn test_leader_start_replication() {
 // Reference: section 5.3
 #[test]
 fn test_leader_commit_entry() {
-    let l = testing_logger().new(o!("test" => "commit_entry"));
+    let l = testing_logger();
     let s = new_storage();
     let mut r = new_test_raft(1, vec![1, 2, 3], 10, 1, s.clone(), &l);
     r.become_candidate();
@@ -509,7 +509,7 @@ fn test_leader_commit_entry() {
 // Reference: section 5.3
 #[test]
 fn test_leader_acknowledge_commit() {
-    let l = testing_logger().new(o!("test" => "leader_acknowledge_commit"));
+    let l = testing_logger();
     let mut tests = vec![
         (1, map!(), true),
         (3, map!(), false),
@@ -551,7 +551,7 @@ fn test_leader_acknowledge_commit() {
 // Reference: section 5.3
 #[test]
 fn test_leader_commit_preceding_entries() {
-    let l = testing_logger().new(o!("test" => "leader_commit_preceding_entries"));
+    let l = testing_logger();
     let mut tests = vec![
         vec![],
         vec![empty_entry(2, 2)],
@@ -595,7 +595,7 @@ fn test_leader_commit_preceding_entries() {
 // Reference: section 5.3
 #[test]
 fn test_follower_commit_entry() {
-    let l = testing_logger().new(o!("test" => "vote_request"));
+    let l = testing_logger();
     let mut tests = vec![
         (vec![new_entry(1, 2, SOME_DATA)], 2),
         (
@@ -654,7 +654,7 @@ fn test_follower_commit_entry() {
 // Reference: section 5.3
 #[test]
 fn test_follower_check_msg_append() {
-    let l = testing_logger().new(o!("test" => "follower_check_msg_append"));
+    let l = testing_logger();
     let ents = vec![empty_entry(1, 2), empty_entry(2, 3)];
     let mut tests = vec![
         // match with committed entries
@@ -711,7 +711,7 @@ fn test_follower_check_msg_append() {
 // Reference: section 5.3
 #[test]
 fn test_follower_append_entries() {
-    let l = testing_logger().new(o!("test" => "follower_append_entries"));
+    let l = testing_logger();
     let mut tests = vec![
         (
             3,
@@ -782,7 +782,7 @@ fn test_follower_append_entries() {
 // Reference: section 5.3, figure 7
 #[test]
 fn test_leader_sync_follower_log() {
-    let l = testing_logger().new(o!("test" => "leader_sync_follower_log"));
+    let l = testing_logger();
     let ents = vec![
         empty_entry(1, 2),
         empty_entry(1, 3),
@@ -901,7 +901,7 @@ fn test_leader_sync_follower_log() {
 // Reference: section 5.4.1
 #[test]
 fn test_vote_request() {
-    let l = testing_logger().new(o!("test" => "vote_request"));
+    let l = testing_logger();
     let mut tests = vec![
         (vec![empty_entry(1, 2)], 2),
         (vec![empty_entry(1, 2), empty_entry(2, 3)], 3),
@@ -958,7 +958,7 @@ fn test_vote_request() {
 // Reference: section 5.4.1
 #[test]
 fn test_voter() {
-    let l = testing_logger().new(o!("test" => "voter"));
+    let l = testing_logger();
     let mut tests = vec![
         // same logterm
         (vec![empty_entry(1, 2)], 1, 2, false),
@@ -1008,7 +1008,7 @@ fn test_voter() {
 // Reference: section 5.4.2
 #[test]
 fn test_leader_only_commits_log_from_current_term() {
-    let l = testing_logger().new(o!("test" => "leader_only_commits_log_from_current_term"));
+    let l = testing_logger();
     let ents = vec![empty_entry(1, 2), empty_entry(2, 3)];
     let mut tests = vec![
         // do not commit log entries in previous terms

--- a/harness/tests/integration_cases/test_raft_snap.rs
+++ b/harness/tests/integration_cases/test_raft_snap.rs
@@ -37,7 +37,7 @@ fn testing_snap() -> Snapshot {
 
 #[test]
 fn test_sending_snapshot_set_pending_snapshot() {
-    let l = testing_logger().new(o!("test" => "sending_snapshot_set_pending_snapshot"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
@@ -60,7 +60,7 @@ fn test_sending_snapshot_set_pending_snapshot() {
 
 #[test]
 fn test_pending_snapshot_pause_replication() {
-    let l = testing_logger().new(o!("test" => "pending_snapshot_pause_replication"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
@@ -76,7 +76,7 @@ fn test_pending_snapshot_pause_replication() {
 
 #[test]
 fn test_snapshot_failure() {
-    let l = testing_logger().new(o!("test" => "snapshot_failure"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
@@ -97,7 +97,7 @@ fn test_snapshot_failure() {
 
 #[test]
 fn test_snapshot_succeed() {
-    let l = testing_logger().new(o!("test" => "snapshot_succeed"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
@@ -118,7 +118,7 @@ fn test_snapshot_succeed() {
 
 #[test]
 fn test_snapshot_abort() {
-    let l = testing_logger().new(o!("test" => "snapshot_abort"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 
@@ -140,7 +140,7 @@ fn test_snapshot_abort() {
 // Initialized storage should be at term 1 instead of 0. Otherwise the case will fail.
 #[test]
 fn test_snapshot_with_min_term() {
-    let l = testing_logger().new(o!("test" => "snapshot_with_min_term"));
+    let l = testing_logger();
     let do_test = |pre_vote: bool| {
         let n1 = new_test_raft_with_prevote(1, vec![1, 2], 10, 1, new_storage(), pre_vote, &l);
         let n2 = new_test_raft_with_prevote(2, vec![], 10, 1, new_storage(), pre_vote, &l);
@@ -156,7 +156,7 @@ fn test_snapshot_with_min_term() {
 
 #[test]
 fn test_request_snapshot() {
-    let l = testing_logger().new(o!("test" => "snapshot_with_min_term"));
+    let l = testing_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
 

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -74,13 +74,13 @@ fn new_raw_node(
     if !peers.is_empty() && !storage.initial_state().unwrap().initialized() {
         storage.initialize_with_conf_state((peers, vec![]));
     }
-    RawNode::with_logger(&config, storage, logger).unwrap()
+    RawNode::new(&config, storage, logger).unwrap()
 }
 
 // test_raw_node_step ensures that RawNode.Step ignore local message.
 #[test]
 fn test_raw_node_step() {
-    let l = testing_logger().new(o!("test" => "sending_snapshot_set_pending_snapshot"));
+    let l = testing_logger();
     for msg_t in MessageType::values() {
         if vec![
             // Vote messages with term 0 will cause panics.
@@ -115,7 +115,7 @@ fn test_raw_node_step() {
 // forward to the new leader and 'send' method does not attach its term
 #[test]
 fn test_raw_node_read_index_to_old_leader() {
-    let l = testing_logger().new(o!("test" => "raw_node_read_index_to_old_leader"));
+    let l = testing_logger();
     let r1 = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let r2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);
     let r3 = new_test_raft(3, vec![1, 2, 3], 10, 1, new_storage(), &l);
@@ -177,7 +177,7 @@ fn test_raw_node_read_index_to_old_leader() {
 // RawNode.propose_conf_change send the given proposal and ConfChange to the underlying raft.
 #[test]
 fn test_raw_node_propose_and_conf_change() {
-    let l = testing_logger().new(o!("test" => "raw_node_restart_from_snapshot"));
+    let l = testing_logger();
     let s = new_storage();
     let mut raw_node = new_raw_node(1, vec![1], 10, 1, s.clone(), &l);
     raw_node.campaign().expect("");
@@ -219,7 +219,7 @@ fn test_raw_node_propose_and_conf_change() {
 // not affect the later propose to add new node.
 #[test]
 fn test_raw_node_propose_add_duplicate_node() {
-    let l = testing_logger().new(o!("test" => "raw_node_propose_add_duplicate_node"));
+    let l = testing_logger();
     let s = new_storage();
     let mut raw_node = new_raw_node(1, vec![1], 10, 1, s.clone(), &l);
     raw_node.campaign().expect("");
@@ -270,7 +270,7 @@ fn test_raw_node_propose_add_duplicate_node() {
 
 #[test]
 fn test_raw_node_propose_add_learner_node() -> Result<()> {
-    let l = testing_logger().new(o!("test" => "raw_node_propose_add_learner_node"));
+    let l = testing_logger();
     let s = new_storage();
     let mut raw_node = new_raw_node(1, vec![1], 10, 1, s.clone(), &l);
     let rd = raw_node.ready();
@@ -314,7 +314,7 @@ fn test_raw_node_propose_add_learner_node() -> Result<()> {
 // to the underlying raft. It also ensures that ReadState can be read out.
 #[test]
 fn test_raw_node_read_index() {
-    let l = testing_logger().new(o!("test" => "raw_node_restart_from_snapshot"));
+    let l = testing_logger();
     let wrequest_ctx = b"somedata".to_vec();
     let wrs = vec![ReadState {
         index: 2u64,
@@ -353,7 +353,7 @@ fn test_raw_node_read_index() {
 // test_raw_node_start ensures that a node can be started correctly.
 #[test]
 fn test_raw_node_start() {
-    let l = testing_logger().new(o!("test" => "raw_node_start"));
+    let l = testing_logger();
     let store = new_storage();
     let mut raw_node = new_raw_node(1, vec![1], 10, 1, store.clone(), &l);
 
@@ -385,7 +385,7 @@ fn test_raw_node_start() {
 
 #[test]
 fn test_raw_node_restart() {
-    let l = testing_logger().new(o!("test" => "raw_node_restart"));
+    let l = testing_logger();
     let entries = vec![empty_entry(1, 1), new_entry(1, 2, Some("foo"))];
 
     let mut raw_node = {
@@ -403,7 +403,7 @@ fn test_raw_node_restart() {
 
 #[test]
 fn test_raw_node_restart_from_snapshot() {
-    let l = testing_logger().new(o!("test" => "raw_node_restart_from_snapshot"));
+    let l = testing_logger();
     let snap = new_snapshot(2, 1, vec![1, 2]);
     let entries = vec![new_entry(1, 3, Some("foo"))];
 
@@ -413,7 +413,7 @@ fn test_raw_node_restart_from_snapshot() {
         store.wl().apply_snapshot(snap).unwrap();
         store.wl().append(&entries).unwrap();
         store.wl().set_hardstate(hard_state(1, 3, 0));
-        RawNode::with_logger(&new_test_config(1, 10, 1), store, &l).unwrap()
+        RawNode::new(&new_test_config(1, 10, 1), store, &l).unwrap()
     };
 
     let rd = raw_node.ready();
@@ -426,7 +426,7 @@ fn test_raw_node_restart_from_snapshot() {
 // when skip_bcast_commit is true.
 #[test]
 fn test_skip_bcast_commit() {
-    let l = testing_logger().new(o!("test" => "skip_bcast_commit"));
+    let l = testing_logger();
     let mut config = new_test_config(1, 10, 1);
     config.skip_bcast_commit = true;
     let s = MemStorage::new_with_conf_state((vec![1, 2, 3], vec![]));

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -54,7 +54,6 @@ pub fn new_test_config(id: u64, election_tick: usize, heartbeat_tick: usize) -> 
         heartbeat_tick,
         max_size_per_msg: NO_LIMIT,
         max_inflight_msgs: 256,
-        tag: id.to_string(),
         ..Default::default()
     }
 }
@@ -118,7 +117,7 @@ pub fn new_test_raft_with_logs(
 }
 
 pub fn new_test_raft_with_config(config: &Config, storage: MemStorage, l: &Logger) -> Interface {
-    Interface::new(Raft::with_logger(config, storage, l).unwrap())
+    Interface::new(Raft::new(config, storage, l).unwrap())
 }
 
 pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,9 +96,6 @@ pub struct Config {
     /// May affect proposal forwarding and follower read.
     pub skip_bcast_commit: bool,
 
-    /// A human-friendly tag used for logging.
-    pub tag: String,
-
     /// Batches every append msg if any append msg already exists
     pub batch_append: bool,
 }
@@ -119,7 +116,6 @@ impl Default for Config {
             max_election_tick: 0,
             read_only_option: ReadOnlyOption::Safe,
             skip_bcast_commit: false,
-            tag: "".into(),
             batch_append: false,
         }
     }
@@ -130,7 +126,6 @@ impl Config {
     pub fn new(id: u64) -> Self {
         Self {
             id,
-            tag: id.to_string(),
             ..Self::default()
         }
     }

--- a/src/progress/inflights.rs
+++ b/src/progress/inflights.rs
@@ -138,11 +138,9 @@ impl Inflights {
 #[cfg(test)]
 mod tests {
     use super::Inflights;
-    use crate::default_logger;
 
     #[test]
     fn test_inflight_add() {
-        let _ = default_logger().new(o!("test" => "inflight_add"));
         let mut inflight = Inflights::new(10);
         for i in 0..5 {
             inflight.add(i);
@@ -199,7 +197,6 @@ mod tests {
 
     #[test]
     fn test_inflight_free_to() {
-        let _ = default_logger().new(o!("test" => "inflight_free_to"));
         let mut inflight = Inflights::new(10);
         for i in 0..10 {
             inflight.add(i);
@@ -252,7 +249,6 @@ mod tests {
 
     #[test]
     fn test_inflight_free_first_one() {
-        let _ = default_logger().new(o!("test" => "inflight_free_first_one"));
         let mut inflight = Inflights::new(10);
         for i in 0..10 {
             inflight.add(i);

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -25,9 +25,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::VecDeque;
-
 use crate::eraftpb::Message;
+use slog::Logger;
+use std::collections::VecDeque;
 
 use hashbrown::{HashMap, HashSet};
 
@@ -129,11 +129,11 @@ impl ReadOnly {
     /// Advances the read only request queue kept by the ReadOnly struct.
     /// It dequeues the requests until it finds the read only request that has
     /// the same context as the given `m`.
-    pub fn advance(&mut self, m: &Message) -> Vec<ReadIndexStatus> {
+    pub fn advance(&mut self, m: &Message, logger: &Logger) -> Vec<ReadIndexStatus> {
         let mut rss = vec![];
         if let Some(i) = self.read_index_queue.iter().position(|x| {
             if !self.pending_read_index.contains_key(x) {
-                panic!("cannot find correspond read state from pending map");
+                fatal!(logger, "cannot find correspond read state from pending map");
             }
             *x == m.context
         }) {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -505,7 +505,6 @@ mod test {
 
     use protobuf::Message as PbMessage;
 
-    use crate::default_logger;
     use crate::eraftpb::{ConfState, Entry, Snapshot};
     use crate::errors::{Error as RaftError, StorageError};
 
@@ -532,7 +531,6 @@ mod test {
 
     #[test]
     fn test_storage_term() {
-        default_logger().new(o!("test" => "storage_term"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![
             (2, Err(RaftError::Store(StorageError::Compacted))),
@@ -555,7 +553,6 @@ mod test {
 
     #[test]
     fn test_storage_entries() {
-        default_logger().new(o!("test" => "storage_entries"));
         let ents = vec![
             new_entry(3, 3),
             new_entry(4, 4),
@@ -620,7 +617,6 @@ mod test {
 
     #[test]
     fn test_storage_last_index() {
-        default_logger().new(o!("test" => "storage_last_index"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let storage = MemStorage::new();
         storage.wl().entries = ents;
@@ -641,7 +637,6 @@ mod test {
 
     #[test]
     fn test_storage_first_index() {
-        default_logger().new(o!("test" => "storage_first_index"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let storage = MemStorage::new();
         storage.wl().entries = ents;
@@ -653,7 +648,6 @@ mod test {
 
     #[test]
     fn test_storage_compact() {
-        default_logger().new(o!("test" => "storage_compact"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![(2, 3, 3, 3), (3, 3, 3, 3), (4, 4, 4, 2), (5, 5, 5, 1)];
         for (i, (idx, windex, wterm, wlen)) in tests.drain(..).enumerate() {
@@ -683,7 +677,6 @@ mod test {
 
     #[test]
     fn test_storage_create_snapshot() {
-        default_logger().new(o!("test" => "storage_create_snapshot"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let nodes = vec![1, 2, 3];
         let mut conf_state = ConfState::default();
@@ -718,7 +711,6 @@ mod test {
 
     #[test]
     fn test_storage_append() {
-        default_logger().new(o!("test" => "storage_append"));
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![
             (
@@ -782,7 +774,6 @@ mod test {
 
     #[test]
     fn test_storage_apply_snapshot() {
-        default_logger().new(o!("test" => "storage_apply_snapshot"));
         let nodes = vec![1, 2, 3];
         let storage = MemStorage::new();
 


### PR DESCRIPTION
This commit brings 2 big changes to the API:

1. No more default logger.

    Users are required to give a logger to use the most of structs in this library. This makes the interface simple and reduces unnecessary dependencies.

2. No more tag scope value.

    Some APIs insert tag into KVs, some don't. It's confusing and easily lead to duplicate KV definitions. Users are required to insert tag into KVs before passing the logger to the library, and there is no more explicit configuration of tag.