### PR TITLE
resolve a potential panic in remove_node

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3065,6 +3065,16 @@ fn test_remove_node() -> Result<()> {
 }
 
 #[test]
+fn test_remove_node_itself() -> Result<()> {
+    let l = testing_logger().new(o!("test" => "remove_node_itself"));
+    let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
+    n1.remove_node(1)?;
+    assert_eq!(n1.prs().learner_ids().iter().next().unwrap(), &2);
+    assert!(n1.prs().voter_ids().is_empty());
+    Ok(())
+}
+
+#[test]
 fn test_promotable() {
     let l = testing_logger().new(o!("test" => "promotable"));
     let id = 1u64;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2440,8 +2440,8 @@ impl<T: Storage> Raft<T> {
     pub fn remove_node(&mut self, id: u64) -> Result<()> {
         self.mut_prs().remove(id)?;
 
-        // do not try to commit or abort transferring if there are no nodes in the cluster.
-        if self.prs().voter_ids().is_empty() && self.prs().learner_ids().is_empty() {
+        // do not try to commit or abort transferring if there are no voters in the cluster.
+        if self.prs().voter_ids().is_empty() {
             return Ok(());
         }
 


### PR DESCRIPTION
There is a bug in `remove_node`:
if there are some learners and only 1 voter in the progress set, and then call `remove_node` on the peer to remove itself, the call will panic.
This PR fixes it.