### PR TITLE
enable all cases for rustfmt and clippy in CI and fix clippy errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add clippy; fi
 
 script:
-  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo fmt -- --check; fi
-  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo clippy -- -D clippy::all; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo fmt --all -- --check; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo clippy --all --all-targets -- -D clippy::all; fi
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo clippy --no-default-features --features prost-codec -- -D clippy::all; fi
   - cargo test --all -- --nocapture
   # Validate benches still work.

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -33,7 +33,7 @@ fn default_logger() -> slog::Logger {
     let case = std::thread::current()
         .name()
         .unwrap()
-        .split(":")
+        .split(':')
         .last()
         .unwrap()
         .to_string();

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -158,12 +158,10 @@ enum Signal {
 }
 
 fn check_signals(receiver: &Arc<Mutex<mpsc::Receiver<Signal>>>) -> bool {
-    loop {
-        match receiver.lock().unwrap().try_recv() {
-            Ok(Signal::Terminate) => return true,
-            Err(TryRecvError::Empty) => return false,
-            Err(TryRecvError::Disconnected) => return true,
-        }
+    match receiver.lock().unwrap().try_recv() {
+        Ok(Signal::Terminate) => true,
+        Err(TryRecvError::Empty) => false,
+        Err(TryRecvError::Disconnected) => true,
     }
 }
 

--- a/harness/tests/integration_cases/test_membership_changes.rs
+++ b/harness/tests/integration_cases/test_membership_changes.rs
@@ -1625,7 +1625,7 @@ fn begin_conf_change<'a>(
     conf_change
 }
 
-fn finalize_conf_change<'a>() -> ConfChange {
+fn finalize_conf_change() -> ConfChange {
     let mut conf_change = ConfChange::default();
     conf_change.set_change_type(ConfChangeType::FinalizeMembershipChange);
     conf_change

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -951,7 +951,7 @@ fn test_candidate_concede() {
     assert_eq!(tt.peers[&1].state, StateRole::Follower);
     assert_eq!(tt.peers[&1].term, 2);
 
-    for (_, p) in &tt.peers {
+    for p in tt.peers.values() {
         assert_eq!(p.raft_log.committed, 3); // All raft logs are committed.
         assert_eq!(p.raft_log.applied, 1); // Raft logs are based on a snapshot with index 1.
         assert_eq!(p.raft_log.last_index(), 3);
@@ -994,7 +994,7 @@ fn test_old_messages() {
     // commit a new entry
     tt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
 
-    for (_, p) in &tt.peers {
+    for p in tt.peers.values() {
         let raft = p.raft.as_ref().unwrap();
         assert_eq!(raft.raft_log.committed, 5);
         assert_eq!(raft.raft_log.applied, 1);
@@ -1037,7 +1037,7 @@ fn test_proposal() {
         // committed index, applied index and last index.
         let want_log = if success { (3, 1, 3) } else { (1, 1, 1) };
 
-        for (_, p) in &nw.peers {
+        for p in nw.peers.values() {
             if let Some(ref raft) = p.raft {
                 let prefix = format!("#{}: ", j);
                 assert_raft_log(&prefix, &raft.raft_log, want_log);
@@ -1063,7 +1063,7 @@ fn test_proposal_by_proxy() {
         // propose via follower
         tt.send(vec![new_message(2, 2, MessageType::MsgPropose, 1)]);
 
-        for (_, p) in &tt.peers {
+        for p in tt.peers.values() {
             if p.raft.is_none() {
                 continue;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,7 +594,7 @@ fn test_logger() -> slog::Logger {
     let case = std::thread::current()
         .name()
         .unwrap()
-        .split(":")
+        .split(':')
         .last()
         .unwrap()
         .to_string();

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -971,7 +971,7 @@ mod test {
         let (last, half) = (offset + num, offset + num / 2);
         let halfe = new_entry(half, half);
 
-        let halfe_size = halfe.compute_size() as u64;
+        let halfe_size = u64::from(halfe.compute_size());
 
         let store = MemStorage::new();
         store
@@ -1340,7 +1340,7 @@ mod test {
             #[allow(deprecated)]
             raft_log.applied_to(committed);
 
-            for (j, idx) in compact.into_iter().enumerate() {
+            for (j, idx) in compact.iter().enumerate() {
                 let res =
                     panic::catch_unwind(AssertUnwindSafe(|| raft_log.store.wl().compact(*idx)));
                 if !(should_panic ^ res.is_ok()) {


### PR DESCRIPTION
Fixes #208.
This PR extends rustfmt and Clippy in CI to cover all cases. Clippy now covers all targets too. It also fixes all the present lint errors.